### PR TITLE
Including path to dynamic libraries into _driver.so for OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -250,6 +250,12 @@ def main():
         if "-arch" not in conf["LDFLAGS"]:
             conf["LDFLAGS"].extend(['-arch', 'i386', '-m32'])
 
+    if 'darwin' in sys.platform:
+        # set path to Cuda dynamic libraries,
+        # as a safe substitute for DYLD_LIBRARY_PATH
+        for lib_dir in conf['CUDADRV_LIB_DIR']:
+            conf["LDFLAGS"].extend(["-Xlinker", "-rpath", "-Xlinker", lib_dir])
+
     ext_kwargs = dict()
 
     if conf["CUDA_ENABLE_GL"]:


### PR DESCRIPTION
This fixes the issue with libcurand I was talking on the maillist (at least on my system). Will not work on OSX 10.4 (rpath was added in 10.5), but I am not sure PyCuda actually supports it.
