### PR TITLE
BUGFIX: MacOSX uses "lib" and not "lib64"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: latin-1 -*-
 
 
-
 def get_config_schema():
     from aksetup_helper import ConfigSchema, Option, \
             IncludeDir, LibraryDir, Libraries, BoostLibraries, \
@@ -35,8 +34,6 @@ def get_config_schema():
         ])
 
 
-
-
 def search_on_path(filenames):
     """Find file on system path."""
     # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/52224
@@ -46,14 +43,11 @@ def search_on_path(filenames):
 
     search_path = environ["PATH"]
 
-    file_found = 0
     paths = search_path.split(pathsep)
     for path in paths:
         for filename in filenames:
             if exists(join(path, filename)):
                 return abspath(join(path, filename))
-
-
 
 
 # verification ----------------------------------------------------------------
@@ -62,7 +56,6 @@ def verify_path(description, paths, names, extensions, subpaths=['/'],
     try:
         from os.path import exists
 
-        defaultname = names[0] + extensions[0]
         prefixes.append("")
         looked_where = []
 
@@ -251,7 +244,6 @@ def main():
     verify_siteconfig(conf)
 
     EXTRA_INCLUDE_DIRS = []
-    EXTRA_LIBRARY_DIRS = []
     EXTRA_LIBRARIES = []
 
     if conf["CUDA_TRACE"]:
@@ -276,8 +268,6 @@ def main():
         # as a safe substitute for DYLD_LIBRARY_PATH
         for lib_dir in conf['CUDADRV_LIB_DIR']:
             conf["LDFLAGS"].extend(["-Xlinker", "-rpath", "-Xlinker", lib_dir])
-
-    ext_kwargs = dict()
 
     if conf["CUDA_ENABLE_GL"]:
         EXTRA_SOURCES.append("src/wrapper/wrap_cudagl.cpp")
@@ -395,8 +385,6 @@ def main():
 
             # 2to3 invocation
             cmdclass={'build_py': build_py})
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The following patch helps me compile pycuda on MacOSX 10.6 with CUDA 4.0.

HTH
