### PR TITLE
Marked _pvt_struct as NumpyExtension (which it is)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -372,7 +372,7 @@ def main():
                     extra_compile_args=conf["CXXFLAGS"],
                     extra_link_args=conf["LDFLAGS"],
                     ),
-                Extension("_pvt_struct",
+                NumpyExtension("_pvt_struct",
                     ["src/wrapper/_pycuda_struct.cpp"],
                     extra_compile_args=conf["CXXFLAGS"],
                     extra_link_args=conf["LDFLAGS"],


### PR DESCRIPTION
Otherwise compilation fails, because it cannot find arrayobject.h.
