### PR TITLE
.gitmodules: use relative submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "bpl-subset"]
 	path = bpl-subset
-	url = http://github.com/inducer/bpl-subset
+	url = ../bpl-subset.git
 [submodule "pycuda/compyte"]
 	path = pycuda/compyte
-	url = http://github.com/inducer/compyte
+	url = ../compyte.git


### PR DESCRIPTION
The previously configured URLs were [project homepages](http://github.com/inducer/bpl-subset), not [Git](https://github.com/inducer/bpl-subset.git)
[repositories](git://github.com/inducer/bpl-subset.git).  Rather than hardcode a full URL here, it's probably
better to just use a relative URL.  `git submodule` interprets URLs
from `.gitmodules` relative to the superproject's origin, so

```
$ git clone git://github.com/inducer/pycuda.git
```

sets up

```
$ git config remote.origin.url
git://github.com/inducer/pycuda.git
```

so the new `.gitmodules` URLs resolve to

```
git://github.com/inducer/bpl-subset.git
git://github.com/inducer/compyte.git
```
