### PR TITLE
Auto init submodules, fixes #13

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -809,3 +809,7 @@ def check_git_submodules():
             if not exists(".dirty-git-ok"):
                 count_down_delay(delay=10)
                 stdout, git_error = _run_git_command(["submodule", "update", "--init"])
+                if git_error is None:
+                    print("-------------------------------------------------------------------------")
+                    print("git submodules initialized successfully")
+                    print("-------------------------------------------------------------------------")


### PR DESCRIPTION
If `setup.py` detects an inconsistent state of the submodules, it will try to initialize/update them, after printing a warning message and waiting for 10 seconds.

This should make _pycuda_ `pip` installable.
