### PR TITLE
Replaced the link to obsolete Pyfft with the link to Reikna.

### DIFF
--- a/doc/source/array.rst
+++ b/doc/source/array.rst
@@ -1166,9 +1166,9 @@ know about them using this function:
 
     .. versionadded: 2011.2
 
-Fast Fourier Transforms
------------------------
+GPGPU Algorithms
+----------------
 
-Bogdan Opanchuk's `pyfft <http://pypi.python.org/pypi/pyfft>`_ offers a
-variety of GPU-based FFT implementations designed to work with
+Bogdan Opanchuk's `reikna <http://pypi.python.org/pypi/reikna>`_ offers a
+variety of GPU-based algorithms (FFT, RNG, matrix multiplication) designed to work with
 :class:`pycuda.gpuarray.GPUArray` objects.


### PR DESCRIPTION
Reikna is stable enough now to serve as a replacement. Or, alternatively, you can close this PR and remove this section altogether; I do not want people to get the wrong idea about Pyfft status.

If this section stays in docs, perhaps other people would want to add links to their packages as well.
