### PR TITLE
ENH: binary comparisons between scalars and GPUArray

### DIFF
--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -617,3 +617,15 @@ def get_if_positive_kernel(crit_dtype, dtype):
             ],
             "result[i] = crit[i] > 0 ? then_[i] : else_[i]",
             "if_positive")
+
+
+@context_dependent_memoize
+def get_scalar_op_kernel(dtype_x, dtype_y, operator):
+    return get_elwise_kernel(
+            "%(tp_x)s *x, %(tp_a)s a, %(tp_y)s *y" % {
+                "tp_x": dtype_to_ctype(dtype_x),
+                "tp_y": dtype_to_ctype(dtype_y),
+                "tp_a": dtype_to_ctype(dtype_x),
+                },
+            "y[i] = x[i] %s a" % operator,
+            "scalarop_kernel")

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -855,6 +855,29 @@ class TestGPUArray:
         with pytest.raises(AssertionError):
             assert (y.get() == X.get()[:3, :5]).all()
 
+    @mark_cuda_test
+    def test_scalar_comparisons(self):
+        a = np.array([1.0, 0.25, 0.1, -0.1, 0.0])
+        a_gpu = gpuarray.to_gpu(a)
+        
+        x_gpu = a_gpu > 0.25
+        x = (a > 0.25).astype(a.dtype)
+        assert (x == x_gpu.get()).all()
+
+        x_gpu = a_gpu <= 0.25
+        x = (a <= 0.25).astype(a.dtype)
+        assert (x == x_gpu.get()).all()
+
+        x_gpu = a_gpu == 0.25
+        x = (a == 0.25).astype(a.dtype)
+        assert (x == x_gpu.get()).all()
+
+        x_gpu = a_gpu == 1  # using an integer scalar
+        x = (a == 1).astype(a.dtype)
+        assert (x == x_gpu.get()).all()
+
+        
+
 
 if __name__ == "__main__":
     # make sure that import failures get reported, instead of skipping the tests.


### PR DESCRIPTION
Hi!

This PR makes it possible to compare GPUArrays with scalars in binary ops such as > , ==, and <=. That is, it enables stuff like:  `x_gpu = a_gpu > 0.25`.

All the best

Tom
