### PR TITLE
Fix PooledDeviceAllocation for Python3

### DIFF
--- a/src/wrapper/mempool.cpp
+++ b/src/wrapper/mempool.cpp
@@ -286,6 +286,7 @@ void pycuda_expose_tools()
       .DEF_SIMPLE_METHOD(free)
       .def("__int__", &cl::ptr)
       .def("__long__", pooled_device_allocation_to_long)
+      .def("__index__", pooled_device_allocation_to_long)
       .def("__len__", &cl::size)
       ;
 


### PR DESCRIPTION
As desribed in issue #51, this will fix the PooledDeviceAllocation in Python3, by
making sure that PooledDeviceAllocation's can be casted to integers. This is
simply done by adding a `__index__` method, analogously to how
the normal DeviceAllocation class does it.
