### PR TITLE
Use appdirs package to create cache in XDG-correct location

### DIFF
--- a/pycuda/compiler.py
+++ b/pycuda/compiler.py
@@ -208,13 +208,13 @@ def compile(source, nvcc="nvcc", options=None, keep=False,
 
     if cache_dir is None:
         from os.path import join
-        from tempfile import gettempdir
-        cache_dir = join(gettempdir(),
-                "pycuda-compiler-cache-v1-%s" % _get_per_user_string())
+        import appdirs
+        cache_dir = os.path.join(appdirs.user_cache_dir("pycuda", "pycuda"),
+                "compiler-cache-v1")
 
-        from os import mkdir
+        from os import makedirs
         try:
-            mkdir(cache_dir)
+            makedirs(cache_dir)
         except OSError, e:
             from errno import EEXIST
             if e.errno != EEXIST:

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,8 @@ def main():
             install_requires=[
                 "pytools>=2011.2",
                 "pytest>=2",
-                "decorator>=3.2.0"
+                "decorator>=3.2.0",
+                "appdirs>=1.4.0"
                 ],
 
             ext_package="pycuda",


### PR DESCRIPTION
This fixes #54.

I haven't tested it with Python 3 or on non-UNIX systems, or updated the ChangeLog. The second argument to appdirs.user_cache_dir is meant to be the "author" - I've put in "pycuda" for now, but let me know if you want it to be something else.
