### PR TITLE
Port examples to Python 3.

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -26,16 +26,16 @@ func(a_gpu, block=(4, 4, 1), grid=(1, 1), shared=0)
 
 a_doubled = numpy.empty_like(a)
 cuda.memcpy_dtoh(a_doubled, a_gpu)
-print "original array:"
-print a
-print "doubled with kernel:"
-print a_doubled
+print("original array:")
+print(a)
+print("doubled with kernel:")
+print(a_doubled)
 
 # alternate kernel invocation -------------------------------------------------
 
 func(cuda.InOut(a), block=(4, 4, 1))
-print "doubled with InOut:"
-print a
+print("doubled with InOut:")
+print(a)
 
 # part 2 ----------------------------------------------------------------------
 
@@ -43,7 +43,7 @@ import pycuda.gpuarray as gpuarray
 a_gpu = gpuarray.to_gpu(numpy.random.randn(4, 4).astype(numpy.float32))
 a_doubled = (2*a_gpu).get()
 
-print "original array:"
-print a_gpu
-print "doubled with gpuarray:"
-print a_doubled
+print("original array:")
+print(a_gpu)
+print("doubled with gpuarray:")
+print(a_doubled)

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,5 +1,5 @@
 # Sample source code from the Tutorial Introduction in the documentation.
-
+from __future__ import print_function
 import pycuda.driver as cuda
 import pycuda.autoinit  # noqa
 from pycuda.compiler import SourceModule

--- a/examples/demo_struct.py
+++ b/examples/demo_struct.py
@@ -30,9 +30,9 @@ do2_ptr = int(struct_arr) + DoubleOpStruct.mem_size
 array1 = DoubleOpStruct(numpy.array([1, 2, 3], dtype=numpy.float32), struct_arr)
 array2 = DoubleOpStruct(numpy.array([0, 4], dtype=numpy.float32), do2_ptr)
 
-print "original arrays"
-print array1
-print array2
+print("original arrays")
+print(array1)
+print(array2)
 
 mod = SourceModule("""
     struct DoubleOperation {
@@ -54,14 +54,14 @@ mod = SourceModule("""
 func = mod.get_function("double_array")
 func(struct_arr, block=(32, 1, 1), grid=(2, 1))
 
-print "doubled arrays"
-print array1
-print array2
+print("doubled arrays")
+print(array1)
+print(array2)
 
 func(numpy.intp(do2_ptr), block=(32, 1, 1), grid=(1, 1))
-print "doubled second only"
-print array1
-print array2
+print("doubled second only")
+print(array1)
+print(array2)
 
 if cuda.get_version() < (4, ):
     func.prepare("P", block=(32, 1, 1))
@@ -72,9 +72,9 @@ else:
     func.prepared_call((2, 1), block, struct_arr)
 
 
-print "doubled again"
-print array1
-print array2
+print("doubled again")
+print(array1)
+print(array2)
 
 if cuda.get_version() < (4, ):
     func.prepared_call((1, 1), do2_ptr)
@@ -82,6 +82,6 @@ else:
     func.prepared_call((1, 1), block, do2_ptr)
 
 
-print "doubled second only again"
-print array1
-print array2
+print("doubled second only again")
+print(array1)
+print(array2)

--- a/examples/demo_struct.py
+++ b/examples/demo_struct.py
@@ -1,5 +1,5 @@
 # prepared invocations and structures -----------------------------------------
-
+from __future__ import print_function
 import pycuda.driver as cuda
 import pycuda.autoinit
 import numpy

--- a/examples/download-examples-from-wiki.py
+++ b/examples/download-examples-from-wiki.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function
 try:
     import xmlrpclib
 except:

--- a/examples/download-examples-from-wiki.py
+++ b/examples/download-examples-from-wiki.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
-import xmlrpclib
-destwiki = xmlrpclib.ServerProxy("http://wiki.tiker.net?action=xmlrpc2")
+import xmlrpc.client
+destwiki = xmlrpc.client.ServerProxy("http://wiki.tiker.net?action=xmlrpc2")
 
 import os
 try:
@@ -9,8 +9,8 @@ try:
 except OSError:
     pass
 
-print "downloading  wiki examples from http://wiki.tiker.net/PyCuda/Examples to wiki-examples/..."
-print "fetching page list..."
+print("downloading  wiki examples from http://wiki.tiker.net/PyCuda/Examples to wiki-examples/...")
+print("fetching page list...")
 all_pages = destwiki.getAllPages()
 
 
@@ -20,7 +20,7 @@ for page in all_pages:
     if not page.startswith("PyCuda/Examples/"):
         continue
 
-    print page
+    print(page)
     try:
         content = destwiki.getPage(page)
 
@@ -33,7 +33,7 @@ for page in all_pages:
 
         outfname = os.path.join("wiki-examples", fname+".py")
         if exists(outfname):
-            print "%s exists, refusing to overwrite." % outfname
+            print("%s exists, refusing to overwrite." % outfname)
         else:
             outf = open(outfname, "w")
             outf.write(code)
@@ -44,13 +44,13 @@ for page in all_pages:
 
             outfname = os.path.join("wiki-examples", att_name)
             if exists(outfname):
-                print "%s exists, refusing to overwrite." % outfname
+                print("%s exists, refusing to overwrite." % outfname)
             else:
                 outf = open(outfname, "w")
                 outf.write(str(content))
                 outf.close()
 
-    except Exception, e:
-        print "Error when processing %s: %s" % (page, e)
+    except Exception as e:
+        print("Error when processing %s: %s" % (page, e))
         from traceback import print_exc
         print_exc()

--- a/examples/download-examples-from-wiki.py
+++ b/examples/download-examples-from-wiki.py
@@ -1,7 +1,11 @@
 #! /usr/bin/env python
 
-import xmlrpc.client
-destwiki = xmlrpc.client.ServerProxy("http://wiki.tiker.net?action=xmlrpc2")
+try:
+    import xmlrpclib
+except:
+    import xmlrpc.client as xmlrpclib
+
+destwiki = xmlrpclib.ServerProxy("http://wiki.tiker.net?action=xmlrpc2")
 
 import os
 try:

--- a/examples/dump_properties.py
+++ b/examples/dump_properties.py
@@ -3,17 +3,17 @@ import pycuda.driver as drv
 
 
 drv.init()
-print "%d device(s) found." % drv.Device.count()
+print("%d device(s) found." % drv.Device.count())
 
 for ordinal in range(drv.Device.count()):
     dev = drv.Device(ordinal)
-    print "Device #%d: %s" % (ordinal, dev.name())
-    print "  Compute Capability: %d.%d" % dev.compute_capability()
-    print "  Total Memory: %s KB" % (dev.total_memory()//(1024))
+    print("Device #%d: %s" % (ordinal, dev.name()))
+    print("  Compute Capability: %d.%d" % dev.compute_capability())
+    print("  Total Memory: %s KB" % (dev.total_memory()//(1024)))
     atts = [(str(att), value) 
-            for att, value in dev.get_attributes().iteritems()]
+            for att, value in dev.get_attributes().items()]
     atts.sort()
     
     for att, value in atts:
-        print "  %s: %s" % (att, value)
+        print("  %s: %s" % (att, value))
 

--- a/examples/dump_properties.py
+++ b/examples/dump_properties.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pycuda.driver as drv
 
 

--- a/examples/fill_gpu_with_nans.py
+++ b/examples/fill_gpu_with_nans.py
@@ -10,7 +10,7 @@ while True:
     if fill_floats < 0:
         raise RuntimeError("couldn't find allocatable size")
     try:
-        print "alloc", fill_floats
+        print("alloc", fill_floats)
         ary = gpuarray.empty((fill_floats,), dtype=numpy.float32)
         break
     except:
@@ -20,5 +20,5 @@ while True:
 
 ary.fill(float("nan"))
 
-print "filled %d out of %d bytes with NaNs" % (fill_floats*4, free_bytes)
+print("filled %d out of %d bytes with NaNs" % (fill_floats*4, free_bytes))
 

--- a/examples/fill_gpu_with_nans.py
+++ b/examples/fill_gpu_with_nans.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pycuda.autoinit
 import pycuda.gpuarray as gpuarray
 import pycuda.driver as cuda

--- a/examples/hello_gpu.py
+++ b/examples/hello_gpu.py
@@ -23,4 +23,4 @@ multiply_them(
         drv.Out(dest), drv.In(a), drv.In(b),
         block=(400,1,1))
 
-print dest-a*b
+print(dest-a*b)

--- a/examples/hello_gpu.py
+++ b/examples/hello_gpu.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pycuda.driver as drv
 import pycuda.tools
 import pycuda.autoinit


### PR DESCRIPTION
Port the examples to python3 for those that have switched to the newer version of the interpreter.