### PR TITLE
add option to compile nvcc's fatbin

### DIFF
--- a/pycuda/compiler.py
+++ b/pycuda/compiler.py
@@ -201,10 +201,11 @@ def compile(source, nvcc="nvcc", options=None, keep=False,
 
     options = options[:]
     if arch is None:
+        from pycuda.driver import Error
         try:
             from pycuda.driver import Context
             arch = "sm_%d%d" % Context.get_device().compute_capability()
-        except RuntimeError:
+        except Error:
             pass
 
     from pycuda.driver import CUDA_DEBUGGING

--- a/pycuda/compiler.py
+++ b/pycuda/compiler.py
@@ -69,7 +69,7 @@ def preprocess_source(source, options, nvcc):
 def compile_plain(source, options, keep, nvcc, cache_dir, target="cubin"):
     from os.path import join
 
-    assert target in ["cubin", "ptx"]
+    assert target in ["cubin", "ptx", "fatbin"]
 
     if cache_dir:
         checksum = _new_md5()
@@ -191,7 +191,7 @@ def compile(source, nvcc="nvcc", options=None, keep=False,
         no_extern_c=False, arch=None, code=None, cache_dir=None,
         include_dirs=[], target="cubin"):
 
-    assert target in ["cubin", "ptx"]
+    assert target in ["cubin", "ptx", "fatbin"]
 
     if not no_extern_c:
         source = 'extern "C" {\n%s\n}\n' % source


### PR DESCRIPTION
Fatbin embeds prebuilt for set of specified real architectures cubin's
and PTX assemblies for set of specified virtual architectures, allowing
driver to load prebuilt cubin if there is any for current real GPU, or
to assemble PTX from closest virtual GPU architecture.

This can be used for distributing CUDA-powered applications without need
to install NVidia CUDA Toolkit (nvcc) and development environment on
target platform.

.cu files can be precompiled to fatbin's on build server with

    fatbin = pycuda.compiler.compile(
        cu_file_text,
        options=[
            "-gencode", "arch=compute_20,code=compute_20",  # build PTX for compute_20 virtual GPU architecture
            "-gencode", "arch=compute_20,code=sm_20",       # build cubin for sm_20 real GPU architecture
            "-gencode", "arch=compute_30,code=compute_30",
            "-gencode", "arch=compute_30,code=sm_30",
        ],
        target="fatbin")

Build server must have NVidia CUDA Toolkit installed, but doesn't need to have CUDA-enabled GPU, since shaders are only compiling.

fatbin's can be distributed on machines without nvcc and loaded using

    cuda_module = pycuda.driver.module_from_buffer(fatbin)
