### PR TITLE
slice size should round up, not down

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -786,7 +786,7 @@ class GPUArray(object):
 
                 array_stride = self.strides[array_axis]
 
-                new_shape.append((stop-start)//idx_stride)
+                new_shape.append((stop-start-1)//idx_stride+1)
                 new_strides.append(idx_stride*array_stride)
                 new_offset += array_stride*start
 


### PR DESCRIPTION
Previously, the following would cause an error:

>>> a = pycuda.gpuarray.to_gpu(numpy.arange(16).reshape((4,4)))
>>> b = a[::3]
>>> b.shape
(2, 4)
>>> b[1]
array([12, 13, 14, 15])
