### PR TITLE
copy() for some discontiguous arrays; __setitem__; get2() provisional…

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -1166,14 +1166,13 @@ def _memcpy_discontig(dst, src, async=False, stream=None):
                 # having no gaps, but the axes could be transposed
                 # so that the order is neither Fortran or C.
                 # So, we attempt to get a contiguous view of dst.
-                dst_flat = dst.ravel(order='K')
-                assert np.byte_bounds(dst) == np.byte_bounds(dst_flat)
+                dst = _as_strided(dst, shape=(dst.size,), strides=(dst.dtype.itemsize,))
                 if async:
-                    drv.memcpy_dtoh_async(dst_flat, src.gpudata, stream=stream)
+                    drv.memcpy_dtoh_async(dst, src.gpudata, stream=stream)
                 else:
-                    drv.memcpy_dtoh(dst_flat, src.gpudata)
+                    drv.memcpy_dtoh(dst, src.gpudata)
         else:
-            src = src.ravel(order='K')
+            src = _as_strided(src, shape=(src.size,), strides=(src.dtype.itemsize,))
             if async:
                 drv.memcpy_htod(dst.gpudata, src, stream=stream)
             else:

--- a/src/cpp/cuda.hpp
+++ b/src/cpp/cuda.hpp
@@ -1671,7 +1671,7 @@ namespace pycuda
     { \
       srcMemoryType = CU_MEMORYTYPE_HOST; \
       py_buffer_wrapper buf_wrapper; \
-      buf_wrapper.get(buf_py.ptr(), PyBUF_ANY_CONTIGUOUS); \
+      buf_wrapper.get(buf_py.ptr(), PyBUF_STRIDED_RO); \
       srcHost = buf_wrapper.m_buf.buf; \
     } \
     \
@@ -1691,7 +1691,7 @@ namespace pycuda
     { \
       dstMemoryType = CU_MEMORYTYPE_HOST; \
       py_buffer_wrapper buf_wrapper; \
-      buf_wrapper.get(buf_py.ptr(), PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE); \
+      buf_wrapper.get(buf_py.ptr(), PyBUF_STRIDED); \
       dstHost = buf_wrapper.m_buf.buf; \
     } \
     \

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -978,6 +978,40 @@ class TestGPUArray:
         assert b_gpu.shape == b.shape
         assert b_gpu.strides == b.strides
 
+    def test_copy(self):
+        from pycuda.curandom import rand as curand
+        a_gpu = curand((3,3))
+
+        for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
+            assert np.allclose(a_gpu[start:stop:step].get(), a_gpu.get()[start:stop:step])
+
+        a_gpu = curand((3,1))
+        for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
+            assert np.allclose(a_gpu[start:stop:step].get(), a_gpu.get()[start:stop:step])
+
+        a_gpu = curand((3,3,3))
+        for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
+            assert np.allclose(a_gpu[start:stop:step,start:stop:step].get(), a_gpu.get()[start:stop:step,start:stop:step])
+
+        a_gpu = curand((3,3,3)).transpose((1,2,0))
+        a = a_gpu.get()
+        for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
+            assert np.allclose(a_gpu[start:stop:step,:,start:stop:step].get(), a_gpu.get()[start:stop:step,:,start:stop:step])
+
+        """# 4-d should work as long as only 2 axes are discontiguous
+        a_gpu = curand((3,3,3,3))
+        a = a_gpu.get()
+        for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
+            assert np.allclose(a_gpu[start:stop:step,:,start:stop:step,:].get(), a_gpu.get()[start:stop:step,:,start:stop:step,:])"""
+
+    def test_get(self):
+        import pycuda.gpuarray as gpuarray
+        a = np.random.normal(0., 1., (4,4))
+        a_gpu = gpuarray.to_gpu(a)
+        
+        assert np.allclose(a_gpu.get(), a)
+        assert np.allclose(a_gpu[1:3,1:3].get(), a[1:3,1:3])
+
 if __name__ == "__main__":
     # make sure that import failures get reported, instead of skipping the tests.
     import pycuda.autoinit  # noqa

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -1004,13 +1004,18 @@ class TestGPUArray:
         for start, stop, step in [(0,3,1), (1,2,1), (0,3,3)]:
             assert np.allclose(a_gpu[start:stop:step,:,start:stop:step].get(), a_gpu.get()[start:stop:step,:,start:stop:step])
 
-    def test_get(self):
+    def test_get_set(self):
         import pycuda.gpuarray as gpuarray
+
         a = np.random.normal(0., 1., (4,4))
         a_gpu = gpuarray.to_gpu(a)
-        
         assert np.allclose(a_gpu.get(), a)
         assert np.allclose(a_gpu[1:3,1:3].get(), a[1:3,1:3])
+
+        a = np.random.normal(0., 1., (4,4,4)).transpose((1,2,0))
+        a_gpu = gpuarray.to_gpu(a)
+        assert np.allclose(a_gpu.get(), a)
+        assert np.allclose(a_gpu[1:3,1:3,1:3].get(), a[1:3,1:3,1:3])
 
 if __name__ == "__main__":
     # make sure that import failures get reported, instead of skipping the tests.

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -998,11 +998,11 @@ class TestGPUArray:
         for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
             assert np.allclose(a_gpu[start:stop:step,:,start:stop:step].get(), a_gpu.get()[start:stop:step,:,start:stop:step])
 
-        """# 4-d should work as long as only 2 axes are discontiguous
+        # 4-d should work as long as only 2 axes are discontiguous
         a_gpu = curand((3,3,3,3))
         a = a_gpu.get()
-        for start, stop, step in [(0,3,1), (1,2,1), (0,3,2), (0,3,3)]:
-            assert np.allclose(a_gpu[start:stop:step,:,start:stop:step,:].get(), a_gpu.get()[start:stop:step,:,start:stop:step,:])"""
+        for start, stop, step in [(0,3,1), (1,2,1), (0,3,3)]:
+            assert np.allclose(a_gpu[start:stop:step,:,start:stop:step].get(), a_gpu.get()[start:stop:step,:,start:stop:step])
 
     def test_get(self):
         import pycuda.gpuarray as gpuarray


### PR DESCRIPTION
Adds a private function _copy() that copies either a GPUArray/ndarray to another GPUArray/ndarray. The two arrays must have the same shape and dtype. They must be <= 3d. They must have the same order and must be contiguous along the minor axis, but otherwise don't have to have the same strides. Sorry that it's verbose; I can compact it later if it's decided to keep it.

This function is used in copy() and __setitem__(), and a dumbly-named get2() method which doesn't automatically reshape arrays with the same size but different shape. I wasn't sure what the right thing to do here was.

There isn't an asynchronous version because I'm not familiar yet with how that works.