### PR TITLE
register_host_memory corrected to pin the array length in bytes, rather than elements

### DIFF
--- a/src/wrapper/wrap_cudadrv.cpp
+++ b/src/wrapper/wrap_cudadrv.cpp
@@ -484,7 +484,7 @@ namespace
 
     std::auto_ptr<registered_host_memory> regmem(
         new registered_host_memory(
-          PyArray_DATA(ary.ptr()), PyArray_SIZE(ary.ptr()), flags, ary));
+          PyArray_DATA(ary.ptr()), PyArray_NBYTES(ary.ptr()), flags, ary));
 
     PyObject *new_array_ptr = PyArray_FromInterface(ary.ptr());
     if (new_array_ptr == Py_NotImplemented)


### PR DESCRIPTION
Replaced PyArray_SIZE(ary) with PyArray_NBYTES(ary).

pycuda.driver.register_host_memory() was passing
the size of the array in elements, rather than
the length of the array in bytes when
creating a register_host_memory class.
This resulted in "Invalid Argument" errors
when calling asynchronous memory copies on
the entire array.

This solves the issues in #46.