### PR TITLE
Fix stream parameters in asynchronous methods.

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -236,7 +236,7 @@ class GPUArray(object):
             _memcpy_discontig(self, ary, async=async, stream=stream)
 
     def set_async(self, ary, stream=None):
-        return self.set(ary, async=True, stream=None)
+        return self.set(ary, async=True, stream=stream)
 
     def get(self, ary=None, pagelocked=False, async=False, stream=None):
         if ary is None:
@@ -1191,7 +1191,7 @@ def _memcpy_discontig(dst, src, async=False, stream=None):
 
     if len(shape) == 2:
         if async:
-            copy(stream=stream)
+            copy(stream)
         else:
             copy(aligned=True)
 
@@ -1206,7 +1206,7 @@ def _memcpy_discontig(dst, src, async=False, stream=None):
 
         copy.depth = shape[2]
         if async:
-            copy(stream=stream)
+            copy(stream)
         else:
             copy()
 


### PR DESCRIPTION
Within `gpuarray.set_async`, the `stream` keyword
argument in the call to `gpuarray.set` was
always set to `None`.

``` python
return self.set(ary, async=True, stream=None)
```

This keyword argument is now always set to value
supplied in the arguments to `gpuarray.set_async`.

```python
return self.set(ary, async=True, stream=stream)
```

Within `_memcpy_discontig`, `Memcpy2D.__call__`
was being called for asynchronous cases as follows:

```python
copy(stream=stream)
```
However, this does not match the C++ function
definition. Instead, they are now called as follows:

```python
copy(stream)
```