### PR TITLE
Add ability to set real and imaginary components of complex numbers

### DIFF
--- a/pycuda/cuda/pycuda-complex.hpp
+++ b/pycuda/cuda/pycuda-complex.hpp
@@ -87,6 +87,10 @@ struct complex {
   value_type real() const { return _M_re; }
   __device__
   value_type imag() const { return _M_im; }
+  __device__
+  value_type &real() { return _M_re; }
+  __device__
+  value_type &imag() { return _M_im; }
 
   // Arithmetic op= operations involving one real argument.
 
@@ -223,6 +227,8 @@ struct _STLP_CLASS_DECLSPEC complex<float> {
   // Element access.
   value_type __device__ real() const { return _M_re; }
   value_type __device__ imag() const { return _M_im; }
+  value_type & __device__ real() { return _M_re; }
+  value_type & __device__ imag() { return _M_im; }
 
   // Arithmetic op= operations involving one real argument.
 
@@ -393,6 +399,10 @@ struct _STLP_CLASS_DECLSPEC complex<double> {
   value_type real() const { return _M_re; }
   __device__
   value_type imag() const { return _M_im; }
+  __device__
+  value_type &real() { return _M_re; }
+  __device__
+  value_type &imag() { return _M_im; }
 
   // Arithmetic op= operations involving one real argument.
 

--- a/pycuda/cuda/pycuda-complex.hpp
+++ b/pycuda/cuda/pycuda-complex.hpp
@@ -88,9 +88,9 @@ struct complex {
   __device__
   value_type imag() const { return _M_im; }
   __device__
-  value_type &real() { return _M_re; }
+  void real(value_type val) { _M_re = val; }
   __device__
-  value_type &imag() { return _M_im; }
+  void imag(value_type val) { _M_im = val; }
 
   // Arithmetic op= operations involving one real argument.
 
@@ -227,8 +227,8 @@ struct _STLP_CLASS_DECLSPEC complex<float> {
   // Element access.
   value_type __device__ real() const { return _M_re; }
   value_type __device__ imag() const { return _M_im; }
-  value_type & __device__ real() { return _M_re; }
-  value_type & __device__ imag() { return _M_im; }
+  void __device__ real(value_type val) { _M_re = val; }
+  void __device__ imag(value_type val) { _M_im = val; }
 
   // Arithmetic op= operations involving one real argument.
 
@@ -400,9 +400,9 @@ struct _STLP_CLASS_DECLSPEC complex<double> {
   __device__
   value_type imag() const { return _M_im; }
   __device__
-  value_type &real() { return _M_re; }
+  void real(value_type val) { _M_re = val; }
   __device__
-  value_type &imag() { return _M_im; }
+  void imag(value_type val) { _M_im = val; }
 
   // Arithmetic op= operations involving one real argument.
 


### PR DESCRIPTION
This PR adds return by reference versions of real() and imag() to allow setting of the real and imaginary parts of a complex number in a kernel.  Technically this is possible now by accessing ```_M_re``` and ```_M_im``` directly but that's bad practice.