### PR TITLE
extFPTextureSurfaces

### DIFF
--- a/pycuda/cuda/pycuda-helpers.hpp
+++ b/pycuda/cuda/pycuda-helpers.hpp
@@ -1,12 +1,12 @@
 #include <pycuda-complex.hpp>
-
+#include <surface_functions.h>
 #ifndef _AFJKDASLFSADHF_HEADER_SEEN_PYCUDA_HELPERS_HPP
 #define _AFJKDASLFSADHF_HEADER_SEEN_PYCUDA_HELPERS_HPP
 
 extern "C++" {
   // "double-precision" textures ------------------------------------------------
   /* Thanks to Nathan Bell <nbell@nvidia.com> for help in figuring this out. */
-
+ 
   typedef float fp_tex_float;
   typedef int2 fp_tex_double;
   typedef uint2 fp_tex_cfloat;
@@ -34,6 +34,8 @@ extern "C++" {
     return __hiloint2double(v.y, v.x);
   }
 
+// 2D functionality
+
   template <enum cudaTextureReadMode read_mode>
   __device__ double fp_tex2D(texture<fp_tex_double, 2, read_mode> tex, int i, int j)
   {
@@ -42,31 +44,172 @@ extern "C++" {
   }
 
   template <enum cudaTextureReadMode read_mode>
+  __device__ pycuda::complex<float> fp_tex2D(texture<fp_tex_cfloat, 2, read_mode> tex, int i, int j)
+  {
+    fp_tex_cfloat v = tex2D(tex, i, j);
+    return pycuda::complex<float>(__int_as_float(v.x), __int_as_float(v.y));
+  }
+
+  template <enum cudaTextureReadMode read_mode>
+  __device__ pycuda::complex<double> fp_tex2D(texture<fp_tex_cdouble, 2, read_mode> tex, int i, int j)
+  {
+    fp_tex_cdouble v = tex2D(tex, i, j);
+    return pycuda::complex<double>(__hiloint2double(v.y, v.x), __hiloint2double(v.w, v.z));
+  }
+
+  // 3D functionality
+
+  template <enum cudaTextureReadMode read_mode>
   __device__ double fp_tex3D(texture<fp_tex_double, 3, read_mode> tex, int i, int j, int k)
   {
     fp_tex_double v = tex3D(tex, i, j, k);
     return __hiloint2double(v.y, v.x);
   }
 
+  template <enum cudaTextureReadMode read_mode>
+  __device__ pycuda::complex<float> fp_tex3D(texture<fp_tex_cfloat, 3, read_mode> tex, int i, int j, int k)
+  {
+    fp_tex_cfloat v = tex3D(tex, i, j, k);
+    return pycuda::complex<float>(__int_as_float(v.x), __int_as_float(v.y));
+  }
+
+  template <enum cudaTextureReadMode read_mode>
+  __device__ pycuda::complex<double> fp_tex3D(texture<fp_tex_cdouble, 3, read_mode> tex, int i, int j, int k)
+  {
+    fp_tex_cdouble v = tex3D(tex, i, j, k);
+    return pycuda::complex<double>(__hiloint2double(v.y, v.x), __hiloint2double(v.w, v.z));
+  }
+
+  // FP_Surfaces with complex supprt
+
+  __device__ void fp_surf2DLayeredwrite(double var,surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_double auxvar;
+    auxvar.x =  __double2loint(var);
+    auxvar.y =  __double2hiint(var);
+    surf2DLayeredwrite(auxvar, surf, i*sizeof(fp_tex_double), j, layer, mode);
+  }
+
+  __device__ void fp_surf2DLayeredwrite(pycuda::complex<float> var,surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cfloat auxvar;
+    auxvar.x =  __float_as_int(var._M_re);
+    auxvar.y =  __float_as_int(var._M_im);
+    surf2DLayeredwrite(auxvar, surf, i*sizeof(fp_tex_cfloat), j, layer,mode);
+  }
+
+  __device__ void fp_surf2DLayeredwrite(pycuda::complex<double> var,surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cdouble auxvar;
+    auxvar.x =  __double2loint(var._M_re);
+    auxvar.y =  __double2hiint(var._M_re);
+
+    auxvar.z = __double2loint(var._M_im);
+    auxvar.w = __double2hiint(var._M_im);
+    surf2DLayeredwrite(auxvar, surf, i*sizeof(fp_tex_cdouble), j, layer,mode);
+  }
+
+  __device__ void fp_surf3Dwrite(double var,surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_double auxvar;
+    auxvar.x =  __double2loint(var);
+    auxvar.y =  __double2hiint(var);
+    surf3Dwrite(auxvar, surf, i*sizeof(fp_tex_double), j, k,mode);
+  }
+
+  __device__ void fp_surf3Dwrite(pycuda::complex<float> var,surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cfloat auxvar;
+    auxvar.x =  __float_as_int(var._M_re);
+    auxvar.y =  __float_as_int(var._M_im);
+
+    surf3Dwrite(auxvar, surf, i*sizeof(fp_tex_cfloat), j, k, mode);
+  }
+
+  __device__ void fp_surf3Dwrite(pycuda::complex<double> var,surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cdouble auxvar;
+    auxvar.x =  __double2loint(var._M_re);
+    auxvar.y =  __double2hiint(var._M_re);
+
+    auxvar.z = __double2loint(var._M_im);
+    auxvar.w = __double2hiint(var._M_im);
+    surf3Dwrite(auxvar, surf, i*sizeof(fp_tex_cdouble), j, k, mode);
+  }
+
+  __device__ void fp_surf2DLayeredread(double *var, surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_double v;
+    surf2DLayeredread(&v, surf, i*sizeof(fp_tex_double), j, layer, mode);
+    *var = __hiloint2double(v.y, v.x);
+  }
+
+  __device__ void fp_surf2DLayeredread(pycuda::complex<float> *var, surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cfloat v;
+    surf2DLayeredread(&v, surf, i*sizeof(fp_tex_cfloat), j, layer, mode);
+    *var = pycuda::complex<float>(__int_as_float(v.x), __int_as_float(v.y));
+  }
+
+  __device__ void fp_surf2DLayeredread(pycuda::complex<double> *var, surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cdouble v;
+    surf2DLayeredread(&v, surf, i*sizeof(fp_tex_cdouble), j, layer, mode);
+    *var = pycuda::complex<double>(__hiloint2double(v.y, v.x), __hiloint2double(v.w, v.z));
+  }
+
+  __device__ void fp_surf3Dread(double *var, surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_double v;
+    surf3Dread(&v, surf, i*sizeof(fp_tex_double), j, k, mode);
+    *var = __hiloint2double(v.y, v.x);
+  }
+
+  __device__ void fp_surf3Dread(pycuda::complex<float> *var, surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cfloat v;
+    surf3Dread(&v, surf, i*sizeof(fp_tex_cfloat), j, k, mode);
+    *var = pycuda::complex<float>(__int_as_float(v.x), __int_as_float(v.y));
+  }
+
+  __device__ void fp_surf3Dread(pycuda::complex<double> *var, surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode)
+  {
+    fp_tex_cdouble v;
+    surf3Dread(&v, surf, i*sizeof(fp_tex_cdouble), j, k, mode);
+    *var = pycuda::complex<double>(__hiloint2double(v.y, v.x), __hiloint2double(v.w, v.z));
+  }
 #define PYCUDA_GENERATE_FP_TEX_FUNCS(TYPE) \
   template <enum cudaTextureReadMode read_mode> \
   __device__ TYPE fp_tex1Dfetch(texture<TYPE, 1, read_mode> tex, int i) \
   { \
     return tex1Dfetch(tex, i); \
   } \
- \
   template <enum cudaTextureReadMode read_mode> \
   __device__ TYPE fp_tex2D(texture<TYPE, 2, read_mode> tex, int i, int j) \
   { \
     return tex2D(tex, i, j); \
   } \
- \
   template <enum cudaTextureReadMode read_mode> \
   __device__ TYPE fp_tex3D(texture<TYPE, 3, read_mode> tex, int i, int j, int k) \
   { \
     return tex3D(tex, i, j, k); \
+  } \
+  __device__ void fp_surf2DLayeredwrite(TYPE var,surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer,enum cudaSurfaceBoundaryMode mode) \
+  { \
+    surf2DLayeredwrite(var, surf, i*sizeof(TYPE), j, layer, mode); \
+  } \
+  __device__ void fp_surf2DLayeredread(TYPE *var, surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer,enum cudaSurfaceBoundaryMode mode) \
+  { \
+    surf2DLayeredread(var, surf, i*sizeof(TYPE), j, layer, mode); \
+  } \
+  __device__ void fp_surf3Dwrite(TYPE var,surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode) \
+  { \
+    surf3Dwrite(var, surf, i*sizeof(TYPE), j, k, mode); \
+  } \
+  __device__ void fp_surf3Dread(TYPE *var, surface<void, 3> surf, int i, int j, int k, enum cudaSurfaceBoundaryMode mode) \
+  { \
+    surf3Dread(var, surf, i*sizeof(TYPE), j, k, mode); \
   }
-
   PYCUDA_GENERATE_FP_TEX_FUNCS(float)
   PYCUDA_GENERATE_FP_TEX_FUNCS(int)
   PYCUDA_GENERATE_FP_TEX_FUNCS(unsigned int)

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -314,10 +314,11 @@ class TestDriver:
     def test_2d_fp_textures(self):
         orden = "C"
         npoints = 32
-        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+        for prec in [np.int16,np.float32,np.float64,np.complex64,np.complex128]:
           prec_str = dtype_to_ctype(prec)
-          if prec == np.complex64: fpName_str = 'cfloat'
-          elif prec == np.complex128: fpName_str = 'cdouble'
+          if prec == np.complex64: fpName_str = 'fp_tex_cfloat'
+          elif prec == np.complex128: fpName_str = 'fp_tex_cdouble'
+          elif prec == np.float64: fpName_str = 'fp_tex_double'
           else: fpName_str = prec_str
           A_cpu = np.zeros([npoints,npoints],order=orden,dtype=prec)
           A_cpu[:] = np.random.rand(npoints,npoints)[:]
@@ -325,7 +326,7 @@ class TestDriver:
 
           myKern = '''
           #include <pycuda-helpers.hpp>
-          texture<fp_tex_fpName, 2, cudaReadModeElementType> mtx_tex;
+          texture<fpName, 2, cudaReadModeElementType> mtx_tex;
 
           __global__ void copy_texture(cuPres *dest)
           {
@@ -356,10 +357,11 @@ class TestDriver:
     def test_3d_fp_textures(self):
         orden = "C"
         npoints = 32
-        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+        for prec in [np.int16,np.float32,np.float64,np.complex64,np.complex128]:
           prec_str = dtype_to_ctype(prec)
-          if prec == np.complex64: fpName_str = 'cfloat'
-          elif prec == np.complex128: fpName_str = 'cdouble'
+          if prec == np.complex64: fpName_str = 'fp_tex_cfloat'
+          elif prec == np.complex128: fpName_str = 'fp_tex_cdouble'
+          elif prec == np.float64: fpName_str = 'fp_tex_double'
           else: fpName_str = prec_str
           A_cpu = np.zeros([npoints,npoints,npoints],order=orden,dtype=prec)
           A_cpu[:] = np.random.rand(npoints,npoints,npoints)[:]
@@ -367,7 +369,7 @@ class TestDriver:
 
           myKern = '''
           #include <pycuda-helpers.hpp>
-          texture<fp_tex_fpName, 3, cudaReadModeElementType> mtx_tex;
+          texture<fpName, 3, cudaReadModeElementType> mtx_tex;
 
           __global__ void copy_texture(cuPres *dest)
           {
@@ -398,10 +400,11 @@ class TestDriver:
     def test_3d_fp_surfaces(self):
         orden = "C"
         npoints = 32
-        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+        for prec in [np.int16,np.float32,np.float64,np.complex64,np.complex128]:
           prec_str = dtype_to_ctype(prec)
-          if prec == np.complex64: fpName_str = 'cfloat'
-          elif prec == np.complex128: fpName_str = 'cdouble'
+          if prec == np.complex64: fpName_str = 'fp_tex_cfloat'
+          elif prec == np.complex128: fpName_str = 'fp_tex_cdouble'
+          elif prec == np.float64: fpName_str = 'fp_tex_double'
           else: fpName_str = prec_str
           A_cpu = np.zeros([npoints,npoints,npoints],order=orden,dtype=prec)
           A_cpu[:] = np.random.rand(npoints,npoints,npoints)[:]
@@ -452,10 +455,11 @@ class TestDriver:
     def test_2d_fp_surfaces(self):
         orden = "C"
         npoints = 32
-        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+        for prec in [np.int16,np.float32,np.float64,np.complex64,np.complex128]:
           prec_str = dtype_to_ctype(prec)
-          if prec == np.complex64: fpName_str = 'cfloat'
-          elif prec == np.complex128: fpName_str = 'cdouble'
+          if prec == np.complex64: fpName_str = 'fp_tex_cfloat'
+          elif prec == np.complex128: fpName_str = 'fp_tex_cdouble'
+          elif prec == np.float64: fpName_str = 'fp_tex_double'
           else: fpName_str = prec_str
           A_cpu = np.zeros([npoints,npoints],order=orden,dtype=prec)
           A_cpu[:] = np.random.rand(npoints,npoints)[:]

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import numpy as np
 import numpy.linalg as la
-from pycuda.tools import mark_cuda_test
+from pycuda.tools import mark_cuda_test, dtype_to_ctype
 import pytest
 from six.moves import range
 
@@ -309,6 +309,198 @@ class TestDriver:
         #print a
         #print dest
         assert la.norm(dest-a) == 0
+
+    @mark_cuda_test
+    def test_2d_fp_textures(self):
+        orden = "C"
+        npoints = 32
+        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+          prec_str = dtype_to_ctype(prec)
+          if prec == np.complex64: fpName_str = 'cfloat'
+          elif prec == np.complex128: fpName_str = 'cdouble'
+          else: fpName_str = prec_str
+          A_cpu = np.zeros([npoints,npoints],order=orden,dtype=prec)
+          A_cpu[:] = np.random.rand(npoints,npoints)[:]
+          A_gpu = gpuarray.zeros(A_cpu.shape,dtype=prec,order=orden)
+
+          myKern = '''
+          #include <pycuda-helpers.hpp>
+          texture<fp_tex_fpName, 2, cudaReadModeElementType> mtx_tex;
+
+          __global__ void copy_texture(cuPres *dest)
+          {
+            int row = blockIdx.x*blockDim.x + threadIdx.x;
+            int col = blockIdx.y*blockDim.y + threadIdx.y;
+
+            dest[row + col*blockDim.x*gridDim.x] = fp_tex2D(mtx_tex, col, row);
+          }
+          '''
+          myKern = myKern.replace('fpName',fpName_str)
+          myKern = myKern.replace('cuPres',prec_str)
+          mod = SourceModule(myKern)
+
+          copy_texture = mod.get_function("copy_texture")
+          mtx_tex = mod.get_texref("mtx_tex")
+          cuBlock = (16,16,1)
+          if cuBlock[0]>npoints:
+            cuBlock = (npoints,npoints,1)
+          cuGrid   = (npoints//cuBlock[0]+1*(npoints % cuBlock[0] != 0 ),npoints//cuBlock[1]+1*(npoints % cuBlock[1] != 0 ),1)
+          copy_texture.prepare('P',texrefs=[mtx_tex])
+          cudaArray = drv.np_to_array(A_cpu,orden,allowSurfaceBind=False)
+          mtx_tex.set_array(cudaArray)
+          copy_texture.prepared_call(cuGrid,cuBlock,A_gpu.gpudata)
+          assert np.sum(np.abs(A_gpu.get()-np.transpose(A_cpu))) == np.array(0,dtype=prec)
+          A_gpu.gpudata.free()
+
+    @mark_cuda_test
+    def test_3d_fp_textures(self):
+        orden = "C"
+        npoints = 32
+        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+          prec_str = dtype_to_ctype(prec)
+          if prec == np.complex64: fpName_str = 'cfloat'
+          elif prec == np.complex128: fpName_str = 'cdouble'
+          else: fpName_str = prec_str
+          A_cpu = np.zeros([npoints,npoints,npoints],order=orden,dtype=prec)
+          A_cpu[:] = np.random.rand(npoints,npoints,npoints)[:]
+          A_gpu = gpuarray.zeros(A_cpu.shape,dtype=prec,order=orden)
+
+          myKern = '''
+          #include <pycuda-helpers.hpp>
+          texture<fp_tex_fpName, 3, cudaReadModeElementType> mtx_tex;
+
+          __global__ void copy_texture(cuPres *dest)
+          {
+            int row   = blockIdx.x*blockDim.x + threadIdx.x;
+            int col   = blockIdx.y*blockDim.y + threadIdx.y;
+            int slice = blockIdx.z*blockDim.z + threadIdx.z;
+            dest[row + col*blockDim.x*gridDim.x + slice*blockDim.x*gridDim.x*blockDim.y*gridDim.y] = fp_tex3D(mtx_tex, slice, col, row);
+          }
+          '''
+          myKern = myKern.replace('fpName',fpName_str)
+          myKern = myKern.replace('cuPres',prec_str)
+          mod = SourceModule(myKern)
+
+          copy_texture = mod.get_function("copy_texture")
+          mtx_tex = mod.get_texref("mtx_tex")
+          cuBlock = (8,8,8)
+          if cuBlock[0]>npoints:
+            cuBlock = (npoints,npoints,npoints)
+          cuGrid   = (npoints//cuBlock[0]+1*(npoints % cuBlock[0] != 0 ),npoints//cuBlock[1]+1*(npoints % cuBlock[1] != 0 ),npoints//cuBlock[2]+1*(npoints % cuBlock[1] != 0 ))
+          copy_texture.prepare('P',texrefs=[mtx_tex])
+          cudaArray = drv.np_to_array(A_cpu,orden,allowSurfaceBind=False)
+          mtx_tex.set_array(cudaArray)
+          copy_texture.prepared_call(cuGrid,cuBlock,A_gpu.gpudata)
+          assert np.sum(np.abs(A_gpu.get()-np.transpose(A_cpu))) == np.array(0,dtype=prec)
+          A_gpu.gpudata.free()
+
+    @mark_cuda_test
+    def test_3d_fp_surfaces(self):
+        orden = "C"
+        npoints = 32
+        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+          prec_str = dtype_to_ctype(prec)
+          if prec == np.complex64: fpName_str = 'cfloat'
+          elif prec == np.complex128: fpName_str = 'cdouble'
+          else: fpName_str = prec_str
+          A_cpu = np.zeros([npoints,npoints,npoints],order=orden,dtype=prec)
+          A_cpu[:] = np.random.rand(npoints,npoints,npoints)[:]
+          A_gpu = gpuarray.to_gpu(A_cpu) # Array randomized
+
+          myKernRW = '''
+          #include <pycuda-helpers.hpp>
+
+          surface<void, cudaSurfaceType3D> mtx_tex;
+
+          __global__ void copy_texture(cuPres *dest, int rw)
+          {
+            int row   = blockIdx.x*blockDim.x + threadIdx.x;
+            int col   = blockIdx.y*blockDim.y + threadIdx.y;
+            int slice = blockIdx.z*blockDim.z + threadIdx.z;
+            int tid = row + col*blockDim.x*gridDim.x + slice*blockDim.x*gridDim.x*blockDim.y*gridDim.y;
+            if (rw==0){
+            cuPres aux = dest[tid];
+            fp_surf3Dwrite(aux, mtx_tex, row, col, slice,cudaBoundaryModeClamp);}
+            else {
+            cuPres aux = 0;
+            fp_surf3Dread(&aux, mtx_tex, slice, col, row, cudaBoundaryModeClamp);
+            dest[tid] = aux;
+            }
+          }
+          '''
+          myKernRW = myKernRW.replace('fpName',fpName_str)
+          myKernRW = myKernRW.replace('cuPres',prec_str)
+          modW = SourceModule(myKernRW)
+
+          copy_texture = modW.get_function("copy_texture")
+          mtx_tex = modW.get_surfref("mtx_tex")
+          cuBlock = (8,8,8)
+          if cuBlock[0]>npoints:
+            cuBlock = (npoints,npoints,npoints)
+          cuGrid   = (npoints//cuBlock[0]+1*(npoints % cuBlock[0] != 0 ),npoints//cuBlock[1]+1*(npoints % cuBlock[1] != 0 ),npoints//cuBlock[2]+1*(npoints % cuBlock[1] != 0 ))
+          copy_texture.prepare('Pi')#,texrefs=[mtx_tex])
+          A_cpu = np.zeros([npoints,npoints,npoints],order=orden,dtype=prec) # To initialize surface with zeros
+          cudaArray = drv.np_to_array(A_cpu,orden,allowSurfaceBind=True)
+          A_cpu = A_gpu.get() # To remember original array
+          mtx_tex.set_array(cudaArray)
+          copy_texture.prepared_call(cuGrid,cuBlock,A_gpu.gpudata, np.int32(0)) # Write random array
+          copy_texture.prepared_call(cuGrid,cuBlock,A_gpu.gpudata, np.int32(1)) # Read, but transposed
+          assert np.sum(np.abs(A_gpu.get()-np.transpose(A_cpu))) == np.array(0,dtype=prec)
+          A_gpu.gpudata.free()
+
+    @mark_cuda_test
+    def test_2d_fp_surfaces(self):
+        orden = "C"
+        npoints = 32
+        for prec in [np.float32,np.float64,np.complex64,np.complex128]:
+          prec_str = dtype_to_ctype(prec)
+          if prec == np.complex64: fpName_str = 'cfloat'
+          elif prec == np.complex128: fpName_str = 'cdouble'
+          else: fpName_str = prec_str
+          A_cpu = np.zeros([npoints,npoints],order=orden,dtype=prec)
+          A_cpu[:] = np.random.rand(npoints,npoints)[:]
+          A_gpu = gpuarray.to_gpu(A_cpu) # Array randomized
+
+          myKernRW = '''
+          #include <pycuda-helpers.hpp>
+
+          surface<void, cudaSurfaceType2DLayered> mtx_tex;
+
+          __global__ void copy_texture(cuPres *dest, int rw)
+          {
+            int row   = blockIdx.x*blockDim.x + threadIdx.x;
+            int col   = blockIdx.y*blockDim.y + threadIdx.y;
+            int layer = 1;
+            int tid = row + col*blockDim.x*gridDim.x ;
+            if (rw==0){
+            cuPres aux = dest[tid];
+            fp_surf2DLayeredwrite(aux, mtx_tex, row, col, layer,cudaBoundaryModeClamp);}
+            else {
+            cuPres aux = 0;
+            fp_surf2DLayeredread(&aux, mtx_tex, col, row, layer, cudaBoundaryModeClamp);
+            dest[tid] = aux;
+            }
+          }
+          '''
+          myKernRW = myKernRW.replace('fpName',fpName_str)
+          myKernRW = myKernRW.replace('cuPres',prec_str)
+          modW = SourceModule(myKernRW)
+
+          copy_texture = modW.get_function("copy_texture")
+          mtx_tex = modW.get_surfref("mtx_tex")
+          cuBlock = (8,8,1)
+          if cuBlock[0]>npoints:
+            cuBlock = (npoints,npoints,1)
+          cuGrid   = (npoints//cuBlock[0]+1*(npoints % cuBlock[0] != 0 ),npoints//cuBlock[1]+1*(npoints % cuBlock[1] != 0 ),1)
+          copy_texture.prepare('Pi')#,texrefs=[mtx_tex])
+          A_cpu = np.zeros([npoints,npoints],order=orden,dtype=prec) # To initialize surface with zeros
+          cudaArray = drv.np_to_array(A_cpu,orden,allowSurfaceBind=True)
+          A_cpu = A_gpu.get() # To remember original array
+          mtx_tex.set_array(cudaArray)
+          copy_texture.prepared_call(cuGrid,cuBlock,A_gpu.gpudata, np.int32(0)) # Write random array
+          copy_texture.prepared_call(cuGrid,cuBlock,A_gpu.gpudata, np.int32(1)) # Read, but transposed
+          assert np.sum(np.abs(A_gpu.get()-np.transpose(A_cpu))) == np.array(0,dtype=prec)
+          A_gpu.gpudata.free()
 
     @mark_cuda_test
     def test_large_smem(self):


### PR DESCRIPTION
Extension for 2D and 3D; Textures and Surfaces with fp support. Added support for direct use of doubles, complex floats, complex doubles. Added a general function "np_to_array" to make CUDA Arrays of supported direct types and hacks for double, float complex and double complex. Finally a test for the added functions.

Will be nice to complete the work for long long integers, but it most use an ugly type cast passing from int2 -> double -> long long, and vice versa. And, for me is not clear if it can be correctly init data for arrays of this type.

Regards,

Roberto