### PR TITLE
Add ability to get handle to CUDA Arrays

### DIFF
--- a/doc/source/driver.rst
+++ b/doc/source/driver.rst
@@ -1283,6 +1283,12 @@ Arrays and Textures
         Return a :class:`ArrayDescriptor3D` object for this 3D array,
         like the one that was used to create it.  CUDA 2.0 and above only.
 
+    .. attribute:: handle
+
+       Return an :class:`int` representing the address in device memory where
+       this array resides.
+
+
 .. class:: SurfaceReference()
 
     .. note::

--- a/src/cpp/cuda.hpp
+++ b/src/cpp/cuda.hpp
@@ -1059,6 +1059,9 @@ namespace pycuda
 
       CUarray handle() const
       { return m_array; }
+
+    intptr_t handle_int() const
+    { return  (intptr_t) m_array; }
   };
 
   // }}}

--- a/src/wrapper/wrap_cudadrv.cpp
+++ b/src/wrapper/wrap_cudadrv.cpp
@@ -1429,6 +1429,7 @@ BOOST_PYTHON_MODULE(_driver)
       .def(py::init<const CUDA_ARRAY3D_DESCRIPTOR &>())
       .DEF_SIMPLE_METHOD(get_descriptor_3d)
 #endif
+      .add_property("handle", &cl::handle_int)
       ;
   }
   // }}}


### PR DESCRIPTION
I added the ability to cast  a pycuda.driver.Array handle pointer to an integer.  I've been using this to perform allocations using pycuda then pass them to previously compiled CUDA code.

Per your email, I've left these features undocumented.