### PR TITLE
Allow the caching behaviour to be controlled globally.

### DIFF
--- a/doc/source/driver.rst
+++ b/doc/source/driver.rst
@@ -2029,9 +2029,13 @@ Just-in-time Compilation
     `None`, it defaults to the current context's device's compute capability.
     If `code` is `None`, it will not be specified.
 
-    `cache_dir` gives the directory used for compiler caching. It has a
-    sensible per-user default. If it is set to `False`, caching is
-    disabled.
+    `cache_dir` gives the directory used for compiler caching.  If `None`
+    then `cache_dir` is taken to be :envvar:`PYCUDA_CACHE_DIR` if set or
+    a sensible per-user default.  If passed as `False`, caching is disabled.
+
+    If the environment variable :envvar:`PYCUDA_DISABLE_CACHE` is set to
+    any value then caching is disabled.  This preference overrides any
+    value of `cache_dir` and can be used to disable caching globally.
 
     This class exhibits the same public interface as :class:`pycuda.driver.Module`, but
     does not inherit from it.

--- a/pycuda/compiler.py
+++ b/pycuda/compiler.py
@@ -214,6 +214,12 @@ def compile(source, nvcc="nvcc", options=None, keep=False,
         keep = True
         options.extend(["-g", "-G"])
 
+    if "PYCUDA_CACHE_DIR" in os.environ and cache_dir is None:
+        cache_dir = os.environ["PYCUDA_CACHE_DIR"]
+
+    if "PYCUDA_DISABLE_CACHE" in os.environ:
+        cache_dir = False
+
     if cache_dir is None:
         from os.path import join
         import appdirs


### PR DESCRIPTION
This enables kernel caching to be controlled at the environmental level.

This is useful as while it is possible to control the caching behaviour by passing `cache_dir` to `SourceModule` this is not always practical.  A good example of this is when one is using the auto-generated reduction kernels.  Here, there is no mechanism to control what values get passed down to `SourceModule`.  The result is an inconsistent caching behaviour for applications that combine their own kernels with those from other source.