### PR TITLE
Add way to access primary context

### DIFF
--- a/src/cpp/cuda.hpp
+++ b/src/cpp/cuda.hpp
@@ -491,6 +491,10 @@ namespace pycuda
         return result;
       }
 #endif
+#if CUDAPP_CUDA_VERSION >= 7000
+      boost::shared_ptr<context> retain_primary_context();
+      void release_primary_context();
+#endif
 
   };
 
@@ -826,9 +830,23 @@ namespace pycuda
   }
 
 
+#if CUDAPP_CUDA_VERSION >= 7000
+  inline
+  boost::shared_ptr<context> device::retain_primary_context()
+  {
+    CUcontext ctx;
+    CUDAPP_CALL_GUARDED(cuDevicePrimaryCtxRetain, (&ctx, m_device));
+    boost::shared_ptr<context> result(new context(ctx));
+    CUDAPP_CALL_GUARDED(cuCtxSetCurrent, (ctx));
+    return result;
+  }
 
-
-
+  inline
+  void device::release_primary_context()
+  {
+    CUDAPP_CALL_GUARDED(cuDevicePrimaryCtxRelease, (m_device));
+  }
+#endif
 
 
 

--- a/src/wrapper/wrap_cudadrv.cpp
+++ b/src/wrapper/wrap_cudadrv.cpp
@@ -258,7 +258,7 @@ namespace
     py_buffer_wrapper buf_wrapper;
     buf_wrapper.get(dest.ptr(), PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE);
 
-    CUDAPP_CALL_GUARDED_THREADED(cuMemcpyAtoH, 
+    CUDAPP_CALL_GUARDED_THREADED(cuMemcpyAtoH,
         (buf_wrapper.m_buf.buf, ary.handle(), index, buf_wrapper.m_buf.len));
   }
 
@@ -952,6 +952,13 @@ BOOST_PYTHON_MODULE(_driver)
 #if CUDAPP_CUDA_VERSION >= 4000
       .DEF_SIMPLE_METHOD(can_access_peer)
 #endif
+#if CUDAPP_CUDA_VERSION >= 7000
+      .def("retain_primary_context", &cl::retain_primary_context,
+          (py::args("self")))
+      .def("release_primary_context", &cl::release_primary_context,
+          (py::args("self")))
+#endif
+
       ;
   }
   // }}}
@@ -1178,7 +1185,7 @@ BOOST_PYTHON_MODULE(_driver)
 
     wrp
       .DEF_SIMPLE_METHOD(get_device_pointer)
-      .def("attach", &cl::attach, 
+      .def("attach", &cl::attach,
         (py::arg("mem_flags"), py::arg("stream")=py::object()))
       ;
   }


### PR DESCRIPTION
Not sure if this would be the best way to do things, but I need a way to access and then make the primary context current for a separate shared lib that uses the runtime api.
