### PR TITLE
Ensure the views from DeviceAllocation.as_buffer are writeable.

### DIFF
--- a/src/cpp/cuda.hpp
+++ b/src/cpp/cuda.hpp
@@ -1499,7 +1499,7 @@ namespace pycuda
             py::handle<>(
 #if PY_VERSION_HEX >= 0x03030000
               PyMemoryView_FromMemory((char *) (get_pointer() + offset), size,
-                PyBUF_READ | PyBUF_WRITE)
+                PyBUF_WRITE)
 #else /* Py2 */
               PyBuffer_FromReadWriteMemory((void *) (get_pointer() + offset), size)
 #endif


### PR DESCRIPTION
This corrects an issue in `DeviceAllocation.as_buffer` whereby the resulting views are read-only.

The issue stems from the combination of a confusing Python API (where read/write views are created by passing `PyBUF_WRITE`) and lax error checking on the part of this API.