### PR TITLE
Update  compiler.py

### DIFF
--- a/pycuda/compiler.py
+++ b/pycuda/compiler.py
@@ -240,7 +240,7 @@ def compile(source, nvcc="nvcc", options=None, keep=False,
     if code is not None:
         options.extend(["-code", code])
 
-    if 'darwin' in sys.platform and sys.maxint == 9223372036854775807:
+    if 'darwin' in sys.platform and sys.maxsize == 9223372036854775807:
         options.append('-m64')
     elif 'win32' in sys.platform and sys.maxsize == 9223372036854775807:
         options.append('-m64')


### PR DESCRIPTION
Solves error generated by using sys.maxint constant in Python 3.1.5^, sys.maxsize is available for use in Python 2.0.0.

Python docs for reference:
- sys.maxint deprecated in Python 3.1.5^: https://docs.python.org/3.1/whatsnew/3.0.html#integers
- sys.maxsize supported in Python 2.6^ : https://docs.python.org/2.6/library/sys.html#sys.maxsize