### PR TITLE
Add access to cuda context handle

### DIFF
--- a/src/cpp/cuda.hpp
+++ b/src/cpp/cuda.hpp
@@ -602,6 +602,9 @@ namespace pycuda
       CUcontext handle() const
       { return m_context; }
 
+      intptr_t handle_int() const
+      { return (intptr_t) m_context; }
+
       bool operator==(const context &other) const
       {
         return m_context == other.m_context;

--- a/src/wrapper/wrap_cudadrv.cpp
+++ b/src/wrapper/wrap_cudadrv.cpp
@@ -1010,6 +1010,7 @@ BOOST_PYTHON_MODULE(_driver)
       .DEF_SIMPLE_METHOD(set_shared_config)
       .staticmethod("set_shared_config")
 #endif
+      .add_property("handle", &cl::handle_int)
       ;
   }
   // }}}


### PR DESCRIPTION
I need access to the context handles to pass to another library, so I added the `handle` property similar to how it is done for the stream wrapper.