### PR TITLE
Provide gpuarray.dot

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -244,6 +244,9 @@ class GPUArray(object):
 
     def set_async(self, ary, stream=None):
         return self.set(ary, async=True, stream=stream)
+        
+    def dot(self, x, stream=None, allocator=None):
+        return dot(self, x, stream=stream, allocator=allocator)
 
     def get(self, ary=None, pagelocked=False, async=False, stream=None):
         if ary is None:


### PR DESCRIPTION
A simple enhancement that adds `A.dot(x)`, versus `skcuda.dot(A, x)`. This is most useful with many dots (but a `__matmul__` operator would be better).

Tests not run, but this is only a three line change that depends on `skcuda.dot`.