### PR TITLE
GPUArrray --> GPUArray

### DIFF
--- a/doc/source/array.rst
+++ b/doc/source/array.rst
@@ -337,7 +337,7 @@ Reductions
 
 .. function:: subset_min(subset, a, stream=None)
 
-Elementwise Functions on :class:`GPUArrray` Instances
+Elementwise Functions on :class:`GPUArray` Instances
 -----------------------------------------------------
 
 .. module:: pycuda.cumath


### PR DESCRIPTION
Fixed a confusing typo in the docs, where the class name "GPUArrray" was spelled incorrectly.