### PR TITLE
make GPUArray .imag, .real and .conj() preserve contiguity

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -679,7 +679,7 @@ class GPUArray(object):
 
         return result
 
-    def reshape(self, *shape):
+    def reshape(self, *shape, order="C"):
         """Gives a new shape to an array without changing its data."""
 
         # TODO: add more error-checking, perhaps
@@ -711,7 +711,8 @@ class GPUArray(object):
                 dtype=self.dtype,
                 allocator=self.allocator,
                 base=self,
-                gpudata=int(self.gpudata))
+                gpudata=int(self.gpudata),
+                order=order)
 
     def ravel(self):
         return self.reshape(self.size)


### PR DESCRIPTION
If a `GPUArray`, `g` is Fortran contiguous,
`g.real`, `g.imag` and `g.conj()` all currently return C-ordered arrays.  The same operations in numpy preserve Fortran ordering.  

With this PR, those routines return F-ordered arrays if the source array is F-ordered.  For C-ordered or non-contiugous arrays, the behaviour will be unchanged.

This PR has some overlap with the existing PR #15, but is more conservative in approach.  (I had also considered putting the code setting 'C' vs. 'F' order into `_new_like_me` itself, but wasn't sure if that might cause problems elsewhere).

The specific use case I have is in calling a function that only supports Fortran-ordered float32 data and I want to run it on both the real and imaginary components of the input and the recombine them.  I already have a Fortran-ordered gpu array, `g`, and would like to be able to call it as  `out = kernel_func(g.real, ...) + 1j*kernel_func(g.imag, ...)`.   I realize this involves some copying of device arrays behind the scenes, but that overhead is relatively small in my application.  Currently this approach fails because the real and imaginary components returned do not respect the ordering of the source array.  After this PR, it works as expected.


The second commit here is independent of the above and just adds an `order` kwarg to `reshape`.  I think this is preferable to the approach taken in #15 where the linear at https://github.com/inducer/pycuda/pull/15/commits/5ea4c97140741024ea71caf1a1e74eba28776fdb#diff-c6f20a28105688a11d8983cd1fce702cR642 seems to assume a 2D shape.

