### PR TITLE
Add test for reverse slicing

### DIFF
--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -495,11 +495,19 @@ def get_fill_kernel(dtype):
 @context_dependent_memoize
 def get_reverse_kernel(dtype):
     return get_elwise_kernel(
-            "%(tp)s *y, %(tp)s *z, int skip" % {
-                "tp": dtype_to_ctype(dtype),
-                },
-            "z[i] = y[n-1-i]",
-            "reverse")
+        "%(tp)s *y, %(tp)s *z, int skip" % {
+            "tp": dtype_to_ctype(dtype),
+        },
+        """
+        skip = abs(skip);
+        if (skip == 1) {
+            z[i] = y[n-1-i];
+        }
+        else {
+            z[i] = y[n-i*skip];
+        }
+        """,
+        "reverse")
 
 
 @context_dependent_memoize

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -495,7 +495,7 @@ def get_fill_kernel(dtype):
 @context_dependent_memoize
 def get_reverse_kernel(dtype):
     return get_elwise_kernel(
-            "%(tp)s *y, %(tp)s *z" % {
+            "%(tp)s *y, %(tp)s *z, int skip" % {
                 "tp": dtype_to_ctype(dtype),
                 },
             "z[i] = y[n-1-i]",

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -500,12 +500,8 @@ def get_reverse_kernel(dtype):
         },
         """
         skip = abs(skip);
-        if (skip == 1) {
-            z[i] = y[n-1-i];
-        }
-        else {
-            z[i] = y[n-i*skip];
-        }
+        size_t N = (n-1)*skip;
+        z[i] = y[N-i*skip];
         """,
         "reverse")
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -926,7 +926,6 @@ class GPUArray(object):
                 gpudata=int(self.gpudata)+new_offset,
                 strides=tuple(new_strides))
 
-        print("Before", tmp)
         if new_strides[0] < 0:
             tmp = tmp.reverse()
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -674,10 +674,6 @@ class GPUArray(object):
         as one-dimensional.
         """
 
-        #if not self.flags.forc:
-        #    raise RuntimeError("only contiguous arrays may "
-        #            "be used as arguments to this operation")
-
         result = self._new_like_me()
 
         func = elementwise.get_reverse_kernel(self.dtype)
@@ -930,6 +926,7 @@ class GPUArray(object):
                 gpudata=int(self.gpudata)+new_offset,
                 strides=tuple(new_strides))
 
+        print("Before", tmp)
         if new_strides[0] < 0:
             tmp = tmp.reverse()
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -866,6 +866,7 @@ class GPUArray(object):
                     # shift required due to [i:j] does not include j
                     start = int(stop + n_step * idx_stride + 1)
                     stop += 1
+                    print(start, stop, idx_stride)
 
                 array_stride = self.strides[array_axis]
 
@@ -929,6 +930,7 @@ class GPUArray(object):
                 gpudata=int(self.gpudata)+new_offset,
                 strides=tuple(new_strides))
 
+        print("Before", tmp)
         if new_strides[0] < 0:
             tmp = tmp.reverse()
 

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -576,18 +576,21 @@ class TestGPUArray:
     def test_reverse_slice(self):
         from pycuda.curandom import rand as curand
 
-        l = 20000
+        l = 10
         a_gpu = curand((l,))
         a = a_gpu.get()
 
         from random import randrange
         for i in range(200):
-            start = randrange(l)
-            end = randrange(start, l)
+            start = 2
+            end = 5
 
             a_gpu_slice = a_gpu[end:start:-2]
             a_slice = a[end:start:-2]
 
+            print("GPU", a_gpu_slice.get())
+            print("CPU", a_slice)
+            print("Ref", a)
             assert la.norm(a_gpu_slice.get()-a_slice) == 0
 
     @mark_cuda_test

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -592,10 +592,6 @@ class TestGPUArray:
             a_gpu_slice = a_gpu[end:start:-step]
             a_slice = a[end:start:-step]
 
-            print("Slice", start, end, step)
-            print("GPU", a_gpu_slice.get())
-            print("CPU", a_slice)
-            print("Ref", a)
             assert la.norm(a_gpu_slice.get()-a_slice) == 0
 
     @mark_cuda_test

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -573,6 +573,24 @@ class TestGPUArray:
             assert la.norm(a_gpu_slice.get()-a_slice) == 0
 
     @mark_cuda_test
+    def test_reverse_slice(self):
+        from pycuda.curandom import rand as curand
+
+        l = 20000
+        a_gpu = curand((l,))
+        a = a_gpu.get()
+
+        from random import randrange
+        for i in range(200):
+            start = randrange(l)
+            end = randrange(start, l)
+
+            a_gpu_slice = a_gpu[end:start:-2]
+            a_slice = a[start:end]
+
+            assert la.norm(a_gpu_slice.get()-a_slice) == 0
+
+    @mark_cuda_test
     def test_2d_slice_c(self):
         from pycuda.curandom import rand as curand
 

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -586,7 +586,7 @@ class TestGPUArray:
             end = randrange(start, l)
 
             a_gpu_slice = a_gpu[end:start:-2]
-            a_slice = a[start:end]
+            a_slice = a[end:start:-2]
 
             assert la.norm(a_gpu_slice.get()-a_slice) == 0
 

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -470,7 +470,7 @@ class TestGPUArray:
         b = a_cpu.get()
 
         for i in range(0, 10):
-            assert a[len(a)-1-i] == b[i]
+            assert a[len(a)-1-i] == b[i], "%s, %s" % (a[len(a)-1-i], b[i])
 
     @mark_cuda_test
     def test_sum(self):
@@ -582,12 +582,17 @@ class TestGPUArray:
 
         from random import randrange
         for i in range(200):
-            start = 2
-            end = 5
+            start = end = 0
+            while end-start < 2:
+                start = randrange(l)
+                end = randrange(start, l)
 
-            a_gpu_slice = a_gpu[end:start:-2]
-            a_slice = a[end:start:-2]
+            step = randrange(1, min(end-start, 20))
 
+            a_gpu_slice = a_gpu[end:start:-step]
+            a_slice = a[end:start:-step]
+
+            print("Slice", start, end, step)
             print("GPU", a_gpu_slice.get())
             print("CPU", a_slice)
             print("Ref", a)


### PR DESCRIPTION
Hi,

I am currently trying to use reverse slicing with a gpuarray (e.g. `[end:start:-step]`), but I am getting an error. I have written quickly a new test in order to reproduce the bug (feel free to discard my merge request if you are able to work on it).

```
>       copy.src_pitch = src_strides[1]
E       OverflowError: can't convert negative value to unsigned int

/usr/local/lib/python3.5/dist-packages/pycuda-2017.1.1-py3.5-linux-x86_64.egg/pycuda/gpuarray.py:1300: OverflowError
```

I have been through the code looking for the definition of src_pitch and I suppose that it comes from cudaMemcpy defined by Nvidia, right? Therefore, it would not be possible to change the unsigned int to a signed one.