### PR TITLE
Fix slicing with negative stride.

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -858,7 +858,7 @@ class GPUArray(object):
 
                 array_stride = self.strides[array_axis]
 
-                new_shape.append((stop-start-1)//idx_stride+1)
+                new_shape.append((abs(stop-start)-1)//abs(idx_stride)+1)
                 new_strides.append(idx_stride*array_stride)
                 new_offset += array_stride*start
 


### PR DESCRIPTION
This small update should fix the shape of arrays indexed with negative strides (when it should be `N` it was `N+2`).  I think the strides and offset calculations are already correct though.