### PR TITLE
Another attempt at supporting non-contiguous arrays

### DIFF
--- a/pycuda/characterize.py
+++ b/pycuda/characterize.py
@@ -6,7 +6,11 @@ import numpy as np
 
 
 def platform_bits():
-    return tuple.__itemsize__ * 8
+    import sys
+    if sys.maxsize > 2**32:
+        return 64
+    else:
+        return 32
 
 
 def has_stack():

--- a/pycuda/cumath.py
+++ b/pycuda/cumath.py
@@ -42,7 +42,7 @@ def _make_unary_array_func(name):
 
         func = elementwise.get_unary_func_kernel(func_name, array.dtype)
         func.prepared_async_call(array._grid, array._block, stream,
-                array.gpudata, out.gpudata, array.mem_size)
+                array, out, array.mem_size)
 
         return out
     return f
@@ -77,7 +77,7 @@ def fmod(arg, mod, stream=None):
 
     func = elementwise.get_fmod_kernel()
     func.prepared_async_call(arg._grid, arg._block, stream,
-            arg.gpudata, mod.gpudata, result.gpudata, arg.mem_size)
+            arg, mod, result, arg.mem_size)
 
     return result
 
@@ -94,7 +94,7 @@ def frexp(arg, stream=None):
 
     func = elementwise.get_frexp_kernel()
     func.prepared_async_call(arg._grid, arg._block, stream,
-            arg.gpudata, sig.gpudata, expt.gpudata, arg.mem_size)
+            arg, sig, expt, arg.mem_size)
 
     return sig, expt
 
@@ -111,7 +111,7 @@ def ldexp(significand, exponent, stream=None):
 
     func = elementwise.get_ldexp_kernel()
     func.prepared_async_call(significand._grid, significand._block, stream,
-            significand.gpudata, exponent.gpudata, result.gpudata,
+            significand, exponent, result,
             significand.mem_size)
 
     return result
@@ -129,7 +129,7 @@ def modf(arg, stream=None):
 
     func = elementwise.get_modf_kernel()
     func.prepared_async_call(arg._grid, arg._block, stream,
-            arg.gpudata, intpart.gpudata, fracpart.gpudata,
+            arg, intpart, fracpart,
             arg.mem_size)
 
     return fracpart, intpart

--- a/pycuda/curandom.py
+++ b/pycuda/curandom.py
@@ -240,7 +240,7 @@ def rand(shape, dtype=np.float32, stream=None):
         raise NotImplementedError;
 
     func.prepared_async_call(result._grid, result._block, stream,
-            result.gpudata, np.random.randint(2**31-1), result.size)
+            result, np.random.randint(2**31-1), result.size)
 
     return result
 

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -350,7 +350,11 @@ class DeferredFunction(object):
         return kwargs
 
     def __call__(self, *args, **kwargs):
-        func = self._deferredmod._delayed_get_function(self._funcname, args)
+        block = kwargs.get('block', None)
+        if block is None or not isinstance(block, tuple) or len(block) != 3:
+            raise ValueError("keyword argument 'block' is required, and must be a 3-tuple of integers")
+        grid = kwargs.get('grid', (1,1))
+        func = self._deferredmod._delayed_get_function(self._funcname, args, grid, block)
         kwargs = self._fix_texrefs(kwargs)
         return func.__call__(*args, **kwargs)
 

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -1,0 +1,484 @@
+"""
+This exports a "deferred" implementation of SourceModule, where compilation
+is delayed until call-time.  Several methods, like get_function(), return
+"deferred" values that are also only evaluated at call-time.
+"""
+
+from pycuda.tools import context_dependent_memoize
+from pycuda.compiler import compile, SourceModule
+import pycuda.driver
+
+import re
+
+class DeferredSource(object):
+    '''
+    Source generator that supports user-directed indentation, nesting
+    ``DeferredSource`` objects, indentation-aware string interpolation,
+    and deferred generation.
+    Use ``+=`` or ``add()`` to add source fragments as strings or
+    other ``DeferredSource`` objects, ``indent()`` or ``dedent()`` to
+    change base indentation, and ``__call__`` or ``generate()`` to
+    generate source.
+    
+    '''
+    def __init__(self, subsources=None, base_indent=0, indent_step=2):
+        self.base_indent = base_indent
+        self.indent_step = indent_step
+        if subsources is None:
+            subsources = []
+        self.subsources = subsources
+
+    def __str__(self):
+        return self.generate()
+
+    def __repr__(self):
+        return repr(self.__str__())
+
+    def __call__(self, indent=0, indent_first=True):
+        return self.generate(indent, indent_first)
+
+    def generate(self, indent=0, indent_first=True, get_list=False):
+        if get_list:
+            retval = []
+        else:
+            retval = ''
+        do_indent = not indent_first
+        for subindent, strip_space, subsource, format_dict in self.subsources:
+            if do_indent:
+                newindent = self.base_indent + indent + subindent
+            else:
+                newindent = 0
+            do_indent = True
+            if isinstance(subsource, DeferredSource):
+                retval = retval + subsource.generate(indent=(indent + subindent), get_list=get_list)
+                continue
+            lines = subsource.split("\n")
+            regex_space = re.compile(r"^(\s*)(.*?)(\s*)$")
+            regex_format = re.compile(r"%\(([^\)]*)\)([a-zA-Z])")
+            minstrip = None
+            newlines = []
+            for line in lines:
+                linelen = len(line)
+                space_match = regex_space.match(line)
+                end_leading_space = space_match.end(1)
+                begin_trailing_space = space_match.start(3)
+                if strip_space:
+                    if linelen == end_leading_space:
+                        # all space, ignore
+                        continue
+                    if minstrip is None or end_leading_space < minstrip:
+                        minstrip = end_leading_space
+                if not format_dict:
+                    newlines.append(line)
+                    continue
+                newlinelist = None
+                newline = ''
+                curpos = 0
+                matches = list(regex_format.finditer(line, end_leading_space))
+                nummatches = len(matches)
+                for match in matches:
+                    formatchar = match.group(2)
+                    name = match.group(1)
+                    matchstart = match.start()
+                    matchend = match.end()
+                    repl = format_dict.get(name, None)
+                    if repl is None:
+                        continue
+                    if (isinstance(repl, DeferredSource) and
+                        nummatches == 1 and
+                        matchstart == end_leading_space):
+                        # only one replacement, and only spaces preceding
+                        space = space_match.group(1)
+                        newlinelist = [ space + x
+                                        for x in repl.generate(get_list=True) ]
+                    else:
+                        newline = newline + line[curpos:matchstart]
+                        newline = newline + (('%' + formatchar) % (repl,))
+                    curpos = matchend
+                if newlinelist is None:
+                    newline = newline + line[curpos:]
+                    newlines.append(newline)
+                else:
+                    newlines.extend(newlinelist)
+                    newlines.append(line[curpos:])
+            indentstr = ' ' * (indent + subindent)
+            for i, line in enumerate(newlines):
+                line = indentstr + line[minstrip:]
+                newlines[i] = line
+            if get_list:
+                retval += newlines
+            else:
+                retval = retval + "\n".join(newlines) + "\n"
+        return retval
+
+    def indent(self, indent_step=None):
+        if indent_step is None:
+            indent_step = self.indent_step
+        self.base_indent += indent_step
+        return self
+
+    def dedent(self, indent_step=None):
+        if indent_step is None:
+            indent_step = self.indent_step
+        self.base_indent -= indent_step
+        return self
+
+    def format_dict(self, format_dict):
+        for subsource in self.subsources:
+            subsource[3] = format_dict
+        return self
+
+    def add(self, other, strip_space=True, format_dict=None):
+        self.subsources.append([self.base_indent, strip_space, other, format_dict])
+        return self
+
+    def __iadd__(self, other):
+        self.add(other)
+        return self
+
+    def __add__(self, other):
+        newgen = DeferredSource(subsources=self.subsources,
+                                base_indent=self.base_indent,
+                                indent_step=self.indent_step)
+        newgen.add(other)
+        return newgen
+
+class DeferredVal(object):
+    '''
+    This is an object that serves as a proxy to an as-yet undetermined
+    object, which is only known at the time when either ``_set_val()``
+    or ``_eval()`` is called.  Any calls to methods listed in the class
+    attribute ``_deferred_method_dict`` are queued until then, at which
+    point the queued method calls are executed in order immediately on
+    the new object.
+    This class must be subclassed, and the class attribute
+    ``_deferred_method_dict`` must contain a mapping from defer-able method
+    names to either ``DeferredVal``, None (same as ``DeferredVal``), or a
+    subclass, which when instantiated, will be assigned (with ``_set_val()``)
+    the return value of the method.
+    There are two ways to set the proxied object.  One is to set it
+    explicitly with ``_set_val(val)``.  The other is to override the method
+    ``_evalbase()`` which should return the new object, and will be called
+    by ``_eval()``.
+    '''
+    __unimpl = object()
+    _deferred_method_dict = None # must be set by subclass
+
+    def __init__(self):
+        self._val_available = False
+        self._val = None
+        self._deferred_method_calls = []
+
+    def __repr__(self):
+        return self._repr(0)
+
+    def _repr(self, indent):
+        indentstr = " " * indent
+        retstrs = []
+        retstrs.append("%s" % (self.__class__,))
+        for dmc in self._deferred_method_calls:
+            (name, args, kwargs, retval) = dmc
+            retstrs.append("  method %s" % (repr(name),))
+            for arg in args:
+                if isinstance(arg, DeferredVal):
+                    retstrs.append("    deferred arg (id=%s)" % (id(arg),))
+                    retstrs.append(arg._repr(indent + 6))
+                else:
+                    retstrs.append("    arg %s" % (repr(arg),))
+            for kwname, arg in kwargs.items():
+                if isinstance(arg, DeferredVal):
+                    retstrs.append("    deferred kwarg %s (id=%s)" % (repr(kwname), id(arg)))
+                    retstrs.append(arg._repr(indent + 6))
+                else:
+                    retstrs.append("    kwarg %s=%s" % (kwname, repr(arg),))
+            retstrs.append("    deferred retval (id=%s)" % (id(retval),))
+        return "\n".join([(indentstr + retstr) for retstr in retstrs])
+
+    def _set_val(self, val):
+        self._val = val
+        self._val_available = True
+        self._eval_methods()
+        return val
+
+    def _evalbase(self):
+        raise NotImplementedError()
+
+    def _eval_list(self, vals):
+        newvals = []
+        for val in vals:
+            if isinstance(val, DeferredVal):
+                val = val._eval()
+            newvals.append(val)
+        return newvals
+
+    def _eval_dict(self, valsdict):
+        newvalsdict = {}
+        for name, val in valsdict.items():
+            if isinstance(val, DeferredVal):
+                val = val._eval()
+            newvalsdict[name] = val
+        return newvalsdict
+
+    def _eval_methods(self):
+        assert(self._val_available)
+        val = self._val
+        for op in self._deferred_method_calls:
+            (methodname, methodargs, methodkwargs, deferredretval) = op
+            methodargs = self._eval_list(methodargs)
+            methodkwargs = self._eval_dict(methodkwargs)
+            retval = getattr(val, methodname)(*methodargs, **methodkwargs)
+            deferredretval._set_val(retval)
+        self._deferred_method_calls = []
+
+    def _eval(self):
+        if not self._val_available:
+            self._val = self._evalbase()
+            self._val_available = True
+            self._eval_methods()
+        return self._val
+
+    def _get_deferred_func(self, _name, _retval):
+        def _deferred_func(*args, **kwargs):
+            if not self._val_available:
+                self._deferred_method_calls.append((_name, args, kwargs, _retval))
+                return _retval
+            args = self._eval_list(args)
+            kwargs = self._eval_dict(kwargs)
+            return getattr(self._val, _name)(*newargs, **newkwargs)
+        _deferred_func.__name__ = _name + ".deferred"
+        return _deferred_func
+
+    def __getattr__(self, name):
+        if self.__class__._deferred_method_dict is None:
+            raise Exception("DeferredVal must be subclassed and the class attribute _deferred_method_dict must be set to a valid dictionary!")
+        if self._val_available:
+            return getattr(self._val, name)
+        deferredclass = self.__class__._deferred_method_dict.get(name, self.__unimpl)
+        if deferredclass is not self.__unimpl:
+            if deferredclass is None:
+                deferredclass = DeferredVal
+            retval = deferredclass()
+            return self._get_deferred_func(name, retval)
+        raise AttributeError("no such attribute (yet): '%s'" % (name,))
+
+# we allow all math operators to be deferred
+_mathops = (
+    '__add__', '__sub__', '__mul__', '__floordiv__', '__mod__',
+    '__divmod__', '__pow__', '__lshift__', '__rshift__', '__and__',
+    '__xor__', '__or__', '__div__', '__truediv__', '__radd__', '__rsub__',
+    '__rmul__', '__rdiv__', '__rtruediv__', '__rfloordiv__', '__rmod__',
+    '__rdivmod__', '__rpow__', '__rlshift__', '__rrshift__', '__rand__',
+    '__rxor__', '__ror__', '__iadd__', '__isub__', '__imul__', '__idiv__',
+    '__itruediv__', '__ifloordiv__', '__imod__', '__ipow__', '__ilshift__',
+    '__irshift__', '__iand__', '__ixor__', '__ior__', '__pos__', '__abs__',
+    '__invert__', '__complex__', '__int__', '__long__', '__float__',
+    '__oct__', '__hex__', '__index__', '__coerce__')
+class DeferredNumeric(DeferredVal):
+    pass
+DeferredNumeric._deferred_method_dict = dict((x, DeferredNumeric)
+                                             for x in _mathops)
+def _get_deferred_attr_func(_name):
+    def _deferred_func(self, *args, **kwargs):
+        return self.__getattr__(_name)(*args, **kwargs)
+    _deferred_func.__name__ = _name
+    return _deferred_func
+for name in _mathops:
+    setattr(DeferredNumeric, name, _get_deferred_attr_func(name))
+
+class DeferredModuleVal(DeferredVal):
+    _deferred_method_dict = {}
+    def __init__(self, sourcemodule, methodstr, name):
+        super(DeferredModuleVal, self).__init__()
+        self._sourcemodule = sourcemodule
+        self._methodstr = methodstr
+        self._name = name
+
+    def _evalbase(self):
+        return getattr(self._sourcemodule.module, self._methodstr)(self._name)
+
+class DeferredTexRef(DeferredModuleVal):
+    _deferred_method_dict = {
+        "set_array": None,
+        "set_address": DeferredNumeric,
+        "set_address_2d": None,
+        "set_format": None,
+        "set_address_mode": None,
+        "set_flags": None,
+        "get_address": DeferredNumeric,
+        "get_flags": DeferredNumeric,
+    }
+
+class DeferredFunction(object):
+    '''
+    This class is a pseudo-replacement of ``pycuda.driver.Function``,
+    but takes a ``DeferredSourceModule`` and a function name as an argument,
+    and queues any call to ``prepare()`` until call-time, at which it
+    calls out to the ``DeferredSourceModule`` object do create the actual
+    Function before preparing (if necessary) and calling the underlying
+    kernel.  NOTE: you may now send the actual ``GPUArrays`` as arguments,
+    rather than their ``.gpudata`` members; this can be helpful to
+    dynamically create kernels.
+    '''
+    def __init__(self, modulelazy, funcname):
+        self._modulelazy = modulelazy
+        self._funcname = funcname
+        self._prepare_args = None
+
+        def get_unimplemented(_methodname):
+            def _unimplemented(self, _methodname=_methodname, *args, **kwargs):
+                raise NotImplementedError("%s does not implement method '%s'" % (type(self), _methodname,))
+            return _unimplemented
+
+        for meth_name in ["set_block_shape", "set_shared_size",
+                "param_set_size", "param_set", "param_seti", "param_setf",
+                "param_setv", "param_set_texref",
+                "launch", "launch_grid", "launch_grid_async"]:
+            setattr(self, meth_name, get_unimplemented(meth_name))
+
+    def _fix_texrefs(self, kwargs):
+        texrefs = kwargs.get('texrefs', None)
+        if texrefs is not None:
+            newtexrefs = []
+            for texref in texrefs:
+                if isinstance(texref, DeferredVal):
+                    texref = texref._eval()
+                newtexrefs.append(texref)
+            kwargs['texrefs'] = newtexrefs
+
+    def __call__(self, *args, **kwargs):
+        func = self._modulelazy.create_function(self._funcname, args)
+        self._fix_texrefs(kwargs)
+        return func.__call__(*args, **kwargs)
+
+    def param_set_texref(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def prepare(self, *args, **kwargs):
+        self._prepare_args = (args, kwargs)
+        return self
+
+    def _do_delayed_prepare(self, func):
+        if self._prepare_args is None:
+            raise Exception("prepared_*_call() requires that prepare() be called first")
+        (prepare_args, prepare_kwargs) = self._prepare_args
+        self._fix_texrefs(prepare_kwargs)
+        func.prepare(*prepare_args, **prepare_kwargs)
+
+    def _generic_prepared_call(self, funcmethodstr, funcmethodargs, funcargs, funckwargs):
+        grid = funcmethodargs[0]
+        block = funcmethodargs[1]
+        func = self._modulelazy._delayed_get_function(self._funcname, funcargs, grid, block)
+        self._do_delayed_prepare(func)
+        newfuncargs = [ getattr(arg, 'gpudata', arg) for arg in funcargs ]
+        fullargs = list(funcmethodargs)
+        fullargs.extend(newfuncargs)
+        return getattr(func, funcmethodstr)(*fullargs, **funckwargs)
+
+    def prepared_call(self, grid, block, *args, **kwargs):
+        return self._generic_prepared_call('prepared_call', (grid, block), args, kwargs)
+
+    def prepared_timed_call(self, grid, block, *args, **kwargs):
+        return self._generic_prepared_call('prepared_timed_call', (grid, block), args, kwargs)
+
+    def prepared_async_call(self, grid, block, stream, *args, **kwargs):
+        return self._generic_prepared_call('prepared_async_call', (grid, block, stream), args, kwargs)
+
+@context_dependent_memoize
+def _delayed_compile_aux(source, compileargs):
+    # re-convert any tuples to lists
+    newcompileargs = []
+    for i, arg in enumerate(compileargs):
+        if isinstance(arg, tuple):
+            arg = list(arg)
+        newcompileargs.append(arg)
+    cubin = compile(source, *newcompileargs)
+
+    from pycuda.driver import module_from_buffer
+    return module_from_buffer(cubin)
+
+class DeferredSourceModule(SourceModule):
+    '''
+    This is an abstract specialization of SourceModule which allows the
+    delay of creating the actual kernel source until call-time, at which
+    point the actual arguments are available and their characteristics can
+    be used to create specific kernels.
+    To support this, ``get_function()`` returns a ``DeferredFunction``
+    object which queues any calls to ``DeferredFunction.prepare()`` and
+    saves them until future calls to ``DeferredFunction.__call__()`` or
+    ``DeferredFunction.prepared_*_call()``.  NOTE: you may now send actual
+    ``GPUArrays`` to these functions rather their ``.gpudata`` members;
+    this can be helpful when creating dynamic kernels.
+    Likewise, ``get_global()``, ``get_texref()`` and ``get_surfref()``
+    return proxy objects that can be stored by ``DeferredFunction.prepare()``
+    and will only be evaluated at call-time.
+    This class must be subclassed and the function ``create_source(self,
+    grid, block, *args)`` must be overridden, returning the kernel source
+    (or ``DeferredSource`` object) that should be compiled.  ``grid``,
+    ``block``, and ``*args`` are the same arguments that were sent to the
+    ``DeferredFunction`` call functions above.
+    The function ``create_key(self, grid, block, *args)`` is always
+    called before ``create_source`` and the key returned (if not None) is
+    used to cache any compiled functions.
+    '''
+    _cache = {}
+
+    def __init__(self, nvcc="nvcc", options=None, keep=False,
+            no_extern_c=False, arch=None, code=None, cache_dir=None,
+            include_dirs=[]):
+        self._arch = arch
+        # tuples below are so _compileargs can be used as a hash key
+        if options is not None:
+            options = tuple(options)
+        include_dirs = tuple(include_dirs)
+        self._compileargs = (nvcc, options, keep, no_extern_c,
+                             arch, code, cache_dir, include_dirs)
+
+    def _delayed_compile(self, source):
+        self._check_arch(self._arch)
+
+        self.module = _delayed_compile_aux(source, self._compileargs)
+        return self.module
+
+    def create_key(self, grid, block, *funcargs):
+        return None
+
+    def create_source(self, grid, block, *funcargs):
+        raise NotImplementedError("create_source must be overridden!")
+
+    def _delayed_get_function(self, funcname, funcargs, grid, block):
+        '''
+        If ``create_key()`` returns non-None, then it is used as the key
+        to cache compiled functions.  Otherwise the return value of
+        ``create_source()`` is used as the key.
+        '''
+        context = pycuda.driver.Context.get_current()
+        funccache = DeferredSourceModule._cache.get(context, None)
+        if funccache is None:
+            funccache = self._cache[context] = {}
+        key = self.create_key(grid, block, *funcargs)
+        funckey = (funcname, key)
+        if key is None or funckey not in funccache:
+            source = self.create_source(grid, block, *funcargs)
+            if isinstance(source, DeferredSource):
+                source = source.generate()
+            if key is None:
+                funckey = (funcname, source)
+        func = funccache.get(funckey, None)
+        if func is None:
+            module = self._delayed_compile(source)
+            func = module.get_function(funcname)
+            funccache[funckey] = func
+        return func
+
+    def get_function(self, name):
+        return DeferredFunction(self, name)
+
+    def get_global(self, name):
+        raise NotImplementedError("Deferred globals in element-wise kernels not supported yet")
+
+    def get_texref(self, name):
+        return DeferredTexRef(self, 'get_texref', name)
+
+    def get_surfref(self, name):
+        raise NotImplementedError("Deferred surfaces in element-wise kernels not supported yet")
+

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -147,7 +147,7 @@ class DeferredVal(object):
     '''
     This is an object that serves as a proxy to an as-yet undetermined
     object, which is only known at the time when either ``_set_val()``
-    or ``_eval()`` is called.  Any calls to methods listed in the class
+    or ``_evalbase()`` is called.  Any calls to methods listed in the class
     attribute ``_deferred_method_dict`` are queued until then, at which
     point the queued method calls are executed in order immediately on
     the new object.

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -244,7 +244,7 @@ class DeferredVal(object):
                 return _retval
             args = self._eval_list(args)
             kwargs = self._eval_dict(kwargs)
-            return getattr(self._val, _name)(*newargs, **newkwargs)
+            return getattr(self._val, _name)(*args, **kwargs)
         _deferred_func.__name__ = _name + ".deferred"
         return _deferred_func
 

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -319,8 +319,8 @@ class DeferredFunction(object):
     rather than their ``.gpudata`` members; this can be helpful to
     dynamically create kernels.
     '''
-    def __init__(self, modulelazy, funcname):
-        self._modulelazy = modulelazy
+    def __init__(self, deferredmod, funcname):
+        self._deferredmod = deferredmod
         self._funcname = funcname
         self._prepare_args = None
 
@@ -346,7 +346,7 @@ class DeferredFunction(object):
             kwargs['texrefs'] = newtexrefs
 
     def __call__(self, *args, **kwargs):
-        func = self._modulelazy.create_function(self._funcname, args)
+        func = self._deferredmod._delayed_get_function(self._funcname, args)
         self._fix_texrefs(kwargs)
         return func.__call__(*args, **kwargs)
 
@@ -367,7 +367,7 @@ class DeferredFunction(object):
     def _generic_prepared_call(self, funcmethodstr, funcmethodargs, funcargs, funckwargs):
         grid = funcmethodargs[0]
         block = funcmethodargs[1]
-        func = self._modulelazy._delayed_get_function(self._funcname, funcargs, grid, block)
+        func = self._deferredmod._delayed_get_function(self._funcname, funcargs, grid, block)
         self._do_delayed_prepare(func)
         newfuncargs = [ getattr(arg, 'gpudata', arg) for arg in funcargs ]
         fullargs = list(funcmethodargs)

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -470,12 +470,12 @@ class DeferredSourceModule(SourceModule):
                 source = source.generate()
             if key is None:
                 funckey = (funcname, source)
-        func = funccache.get(funckey, None)
-        if func is None:
+        modfunc = funccache.get(funckey, None)
+        if modfunc is None:
             module = self._delayed_compile(source)
             func = module.get_function(funcname)
-            funccache[funckey] = func
-        return func
+            modfunc = funccache[funckey] = (module, func)
+        return modfunc[1]
 
     def get_function(self, name):
         return DeferredFunction(self, name)

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -417,8 +417,11 @@ class DeferredSourceModule(SourceModule):
     ``block``, and ``*args`` are the same arguments that were sent to the
     ``DeferredFunction`` call functions above.
     The function ``create_key(self, grid, block, *args)`` is always
-    called before ``create_source`` and the key returned (if not None) is
-    used to cache any compiled functions.
+    called before ``create_source`` and the key returned is used to cache
+    any compiled functions.  Default return value of ``create_key()`` is
+    None, which means to use the function name and generated source as the
+    key.  The return value of ``create_key()`` must be usable as a hash
+    key.
     '''
     _cache = {}
 

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -64,7 +64,7 @@ class ElementwiseSourceModule(DeferredSourceModule):
         super(ElementwiseSourceModule, self).__init__(**compilekwargs)
         self._do_range = do_range
         self._shape_arg_index = shape_arg_index
-        self._init_args = (arguments, operation,
+        self._init_args = (tuple(arguments), operation,
                            name, preamble, loop_prep, after_loop)
 
     def create_key(self, grid, block, *args):

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -463,7 +463,6 @@ class ElementwiseSourceModule(DeferredSourceModule):
             }
             """, format_dict={
                 "arguments": ", ".join(arg.declarator() for arg in arguments),
-                "operation": operation,
                 "name": funcname,
                 "preamble": preamble,
                 "loop_prep": loop_prep,

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -130,7 +130,6 @@ class ElementwiseSourceModule(DeferredSourceModule):
 
         ndim = len(shape)
         numthreads = block[0]
-        shape = np.array(shape)
 
         # Use index of minimum stride in first array as a hint on how to
         # order the traversal of dimensions.  We could probably do something
@@ -148,7 +147,8 @@ class ElementwiseSourceModule(DeferredSourceModule):
             do_reverse = True
         if do_reverse:
             shape = shape[::-1]
-        block_step = np.array(shape)
+        shapearr = np.array(shape)
+        block_step = np.array(shapearr)
         tmp = numthreads
         for dimnum in range(ndim):
             newstep = tmp % block_step[dimnum]
@@ -160,7 +160,7 @@ class ElementwiseSourceModule(DeferredSourceModule):
                 elemstrides = np.array(arg.strides[::-1]) // arg.itemsize
             else:
                 elemstrides = np.array(arg.strides) // arg.itemsize
-            dimelemstrides = elemstrides * shape
+            dimelemstrides = elemstrides * shapearr
             blockelemstrides = elemstrides * block_step
             arrayarginfos.append(
                 (arg_descr.name, tuple(elemstrides), tuple(dimelemstrides), tuple(blockelemstrides))
@@ -172,7 +172,7 @@ class ElementwiseSourceModule(DeferredSourceModule):
         self._shape = shape
         self._block_step = block_step
 
-        key = (self._init_args, grid, block, tuple(self._arrayarginfos))
+        key = (self._init_args, grid, block, shape, tuple(self._arrayarginfos))
 
         return key
 

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -520,10 +520,6 @@ class ElementwiseKernel:
 
         for arg, arg_descr in zip(args, arguments):
             if isinstance(arg_descr, VectorArg):
-                if not arg.flags.forc:
-                    raise RuntimeError("elementwise kernel cannot "
-                            "deal with non-contiguous arrays")
-
                 vectors.append(arg)
                 invocation_args.append(arg)
             else:

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -339,8 +339,8 @@ class ElementwiseSourceModule(DeferredSourceModule):
                        dimnum + 1)
                 for name in arraynames:
                     loop_inds_inc += """
-                      %s_i -= DIMELEMSTRIDE_%s_%d;
-                    """ % (name, name, dimnum)
+                      %s_i += ELEMSTRIDE_%s_%d - DIMELEMSTRIDE_%s_%d;
+                    """ % (name, name, dimnum + 1, name, dimnum)
                 loop_inds_inc.dedent()
                 loop_inds_inc += """
                     }

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -806,7 +806,7 @@ def get_binary_op_kernel(dtype_x, dtype_y, dtype_z, operator):
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
             "z[z_i] = x[x_i] %s y[y_i]" % operator,
-            "multiply")
+            "binary_op")
 
 
 @context_dependent_memoize

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -857,7 +857,7 @@ class GPUArray(object):
 
                 array_stride = self.strides[array_axis]
 
-                new_shape.append((stop-start-1)//idx_stride+1)
+                new_shape.append((abs(stop-start)-1)//abs(idx_stride)+1)
                 new_strides.append(idx_stride*array_stride)
                 new_offset += array_stride*start
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -134,7 +134,7 @@ def _make_binary_op(operator):
                     self.dtype, other.dtype, result.dtype,
                     operator)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, other.gpudata, result.gpudata,
+                    self, other, result,
                     self.mem_size)
 
             return result
@@ -143,7 +143,7 @@ def _make_binary_op(operator):
             func = elementwise.get_scalar_op_kernel(
                     self.dtype, result.dtype, operator)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, other, result.gpudata,
+                    self, other, result,
                     self.mem_size)
             return result
 
@@ -300,47 +300,47 @@ class GPUArray(object):
         """Compute ``out = selffac * self + otherfac*other``,
         where `other` is a vector.."""
         assert self.shape == other.shape
-        if not self.flags.forc or not other.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc or not other.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         func = elementwise.get_axpbyz_kernel(self.dtype, other.dtype, out.dtype)
 
         if add_timer is not None:
             add_timer(3*self.size, func.prepared_timed_call(self._grid,
-                selffac, self.gpudata, otherfac, other.gpudata,
-                out.gpudata, self.mem_size))
+                selffac, self, otherfac, other,
+                out, self.mem_size))
         else:
             func.prepared_async_call(self._grid, self._block, stream,
-                    selffac, self.gpudata, otherfac, other.gpudata,
-                    out.gpudata, self.mem_size)
+                    selffac, self, otherfac, other,
+                    out, self.mem_size)
 
         return out
 
     def _axpbz(self, selffac, other, out, stream=None):
         """Compute ``out = selffac * self + other``, where `other` is a scalar."""
 
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         func = elementwise.get_axpbz_kernel(self.dtype, out.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                selffac, self.gpudata,
-                other, out.gpudata, self.mem_size)
+                selffac, self,
+                other, out, self.mem_size)
 
         return out
 
     def _elwise_multiply(self, other, out, stream=None):
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         func = elementwise.get_binary_op_kernel(self.dtype, other.dtype,
                 out.dtype, "*")
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, other.gpudata,
-                out.gpudata, self.mem_size)
+                self, other,
+                out, self.mem_size)
 
         return out
 
@@ -350,31 +350,31 @@ class GPUArray(object):
            y = n / self
         """
 
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         func = elementwise.get_rdivide_elwise_kernel(self.dtype, out.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, other,
-                out.gpudata, self.mem_size)
+                self, other,
+                out, self.mem_size)
 
         return out
 
     def _div(self, other, out, stream=None):
         """Divides an array by another array."""
 
-        if not self.flags.forc or not other.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc or not other.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         assert self.shape == other.shape
 
         func = elementwise.get_binary_op_kernel(self.dtype, other.dtype,
                 out.dtype, "/")
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, other.gpudata,
-                out.gpudata, self.mem_size)
+                self, other,
+                out, self.mem_size)
 
         return out
 
@@ -554,7 +554,7 @@ class GPUArray(object):
         """fills the array with the specified value"""
         func = elementwise.get_fill_kernel(self.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                value, self.gpudata, self.mem_size)
+                value, self, self.mem_size)
 
         return self
 
@@ -640,7 +640,7 @@ class GPUArray(object):
                 out_dtype=out_dtype)
 
         func.prepared_async_call(self._grid, self._block, None,
-                self.gpudata, result.gpudata, self.mem_size)
+                self, result, self.mem_size)
 
         return result
 
@@ -651,9 +651,9 @@ class GPUArray(object):
         """
 
         if isinstance(other, GPUArray):
-            if not self.flags.forc or not other.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
+            #if not self.flags.forc or not other.flags.forc:
+            #    raise RuntimeError("only contiguous arrays may "
+            #            "be used as arguments to this operation")
 
             assert self.shape == other.shape
 
@@ -666,14 +666,14 @@ class GPUArray(object):
                     self.dtype, other.dtype, result.dtype)
 
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, other.gpudata, result.gpudata,
+                    self, other, result,
                     self.mem_size)
 
             return result
         else:
-            if not self.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
+            #if not self.flags.forc:
+            #    raise RuntimeError("only contiguous arrays may "
+            #            "be used as arguments to this operation")
 
             if new:
                 result = self._new_like_me()
@@ -681,7 +681,7 @@ class GPUArray(object):
                 result = self
             func = elementwise.get_pow_kernel(self.dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    other, self.gpudata, result.gpudata,
+                    other, self, result,
                     self.mem_size)
 
             return result
@@ -713,23 +713,23 @@ class GPUArray(object):
         as one-dimensional.
         """
 
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         result = self._new_like_me()
 
         func = elementwise.get_reverse_kernel(self.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, result.gpudata,
+                self, result,
                 self.mem_size)
 
         return result
 
     def astype(self, dtype, stream=None):
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         if dtype == self.dtype:
             return self.copy()
@@ -738,7 +738,7 @@ class GPUArray(object):
 
         func = elementwise.get_copy_kernel(dtype, self.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                result.gpudata, self.gpudata,
+                result, self,
                 self.mem_size)
 
         return result
@@ -750,9 +750,9 @@ class GPUArray(object):
         order = kwargs.pop("order", "C")
 
         # TODO: add more error-checking, perhaps
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
+        #if not self.flags.forc:
+        #    raise RuntimeError("only contiguous arrays may "
+        #            "be used as arguments to this operation")
 
         if isinstance(shape[0], tuple) or isinstance(shape[0], list):
             shape = tuple(shape[0])
@@ -978,7 +978,7 @@ class GPUArray(object):
 
             func = elementwise.get_real_kernel(dtype, real_dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, result.gpudata,
+                    self, result,
                     self.mem_size)
 
             return result
@@ -989,9 +989,9 @@ class GPUArray(object):
     def imag(self):
         dtype = self.dtype
         if issubclass(self.dtype.type, np.complexfloating):
-            if not self.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
+            #if not self.flags.forc:
+            #    raise RuntimeError("only contiguous arrays may "
+            #            "be used as arguments to this operation")
 
             from pytools import match_precision
             real_dtype = match_precision(np.dtype(np.float64), dtype)
@@ -1003,7 +1003,7 @@ class GPUArray(object):
 
             func = elementwise.get_imag_kernel(dtype, real_dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, result.gpudata,
+                    self, result,
                     self.mem_size)
 
             return result
@@ -1013,9 +1013,9 @@ class GPUArray(object):
     def conj(self):
         dtype = self.dtype
         if issubclass(self.dtype.type, np.complexfloating):
-            if not self.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
+            #if not self.flags.forc:
+            #    raise RuntimeError("only contiguous arrays may "
+            #            "be used as arguments to this operation")
 
             if self.flags.f_contiguous:
                 order = "F"
@@ -1025,7 +1025,7 @@ class GPUArray(object):
 
             func = elementwise.get_conj_kernel(dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, result.gpudata,
+                    self, result,
                     self.mem_size)
 
             return result
@@ -1219,7 +1219,7 @@ def arange(*args, **kwargs):
 
     func = elementwise.get_arange_kernel(dtype)
     func.prepared_async_call(result._grid, result._block, kwargs.get("stream"),
-            result.gpudata, start, step, size)
+            result, start, step, size)
 
     return result
 
@@ -1244,7 +1244,7 @@ def _flip_negative_strides(arrays):
         stride_sign = t[1]
         if len(arrays) > 1:
             if not np.all(t[2:] == stride_sign):
-                raise ValueError("found differing signs in dimension %d: %s" % (axis, t[1:]))
+                raise ValueError("found differing signs in strides for dimension %d (strides for all arrays: %s)" % (axis, [x.strides for x in arrays]))
         if stride_sign == -1:
             if slicer is None:
                 slicer = [slice(None)] * ndim
@@ -1431,7 +1431,7 @@ def take(a, indices, out=None, stream=None):
     a.bind_to_texref_ext(tex_src[0], allow_double_hack=True, allow_complex_hack=True)
 
     func.prepared_async_call(out._grid, out._block, stream,
-            indices.gpudata, out.gpudata, indices.size)
+            indices, out, indices.size)
 
     return out
 
@@ -1473,8 +1473,8 @@ def multi_take(arrays, indices, out=None, stream=None):
             a.bind_to_texref_ext(tex_src[i], allow_double_hack=True)
 
         func.prepared_async_call(indices._grid, indices._block, stream,
-                indices.gpudata,
-                *([o.gpudata for o in out[chunk_slice]]
+                indices,
+                *([o for o in out[chunk_slice]]
                     + [indices.size]))
 
     return out
@@ -1538,8 +1538,8 @@ def multi_take_put(arrays, dest_indices, src_indices, dest_shape=None,
             a.bind_to_texref_ext(src_tr, allow_double_hack=True)
 
         func.prepared_async_call(src_indices._grid,  src_indices._block, stream,
-                dest_indices.gpudata, src_indices.gpudata,
-                *([o.gpudata for o in out[chunk_slice]]
+                dest_indices, src_indices,
+                *([o for o in out[chunk_slice]]
                     + src_offsets_list[chunk_slice]
                     + [src_indices.size]))
 
@@ -1583,9 +1583,9 @@ def multi_put(arrays, dest_indices, dest_shape=None, out=None, stream=None):
             func = make_func_for_chunk_size(vec_count-start_i)
 
         func.prepared_async_call(dest_indices._grid, dest_indices._block, stream,
-                dest_indices.gpudata,
-                *([o.gpudata for o in out[chunk_slice]]
-                    + [i.gpudata for i in arrays[chunk_slice]]
+                dest_indices,
+                *([o for o in out[chunk_slice]]
+                    + [i for i in arrays[chunk_slice]]
                     + [dest_indices.size]))
 
     return out
@@ -1637,7 +1637,7 @@ def if_positive(criterion, then_, else_, out=None, stream=None):
         out = empty_like(then_)
 
     func.prepared_async_call(criterion._grid, criterion._block, stream,
-            criterion.gpudata, then_.gpudata, else_.gpudata, out.gpudata,
+            criterion, then_, else_, out,
             criterion.size)
 
     return out
@@ -1652,14 +1652,14 @@ def _make_binary_minmax_func(which):
                     a.dtype, b.dtype, out.dtype, use_scalar=False)
 
             func.prepared_async_call(a._grid, a._block, stream,
-                    a.gpudata, b.gpudata, out.gpudata, a.size)
+                    a, b, out, a.size)
         elif isinstance(a, GPUArray):
             if out is None:
                 out = empty_like(a)
             func = elementwise.get_binary_minmax_kernel(which,
                     a.dtype, a.dtype, out.dtype, use_scalar=True)
             func.prepared_async_call(a._grid, a._block, stream,
-                    a.gpudata, b, out.gpudata, a.size)
+                    a, b, out, a.size)
         else:  # assuming b is a GPUArray
             if out is None:
                 out = empty_like(b)
@@ -1667,7 +1667,7 @@ def _make_binary_minmax_func(which):
                     b.dtype, b.dtype, out.dtype, use_scalar=True)
             # NOTE: we switch the order of a and b here!
             func.prepared_async_call(b._grid, b._block, stream,
-                    b.gpudata, a, out.gpudata, b.size)
+                    b, a, out, b.size)
         return out
     return f
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -671,7 +671,7 @@ class GPUArray(object):
 
         """
         return self._pow(other,new=False)
-        
+
 
     def reverse(self, stream=None):
         """Return this array in reversed order. The array is treated
@@ -1542,13 +1542,13 @@ def transpose(a, axes=None):
     return a.transpose(axes)
 
 
-def reshape(a, shape):
+def reshape(a, *shape, **kwargs):
     """Gives a new shape to an array without changing its data.
 
     .. versionadded:: 2015.2
     """
 
-    return a.reshape(shape)
+    return a.reshape(*shape, **kwargs)
 
 # }}}
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -1034,10 +1034,10 @@ def _array_like_helper(other_ary, dtype, order):
             order = "F"
         else:
             # array_like routines only return positive strides
-            strides = [np.abs(s) for s in other_ary.strides]
+            _, strides, _ = _compact_positive_strides(other_ary)
             if dtype is not None and dtype != other_ary.dtype:
                 # scale strides by itemsize when dtype is not the same
-                itemsize = other_ary.nbytes // other_ary.size
+                itemsize = other_ary.dtype.itemsize
                 itemsize_ratio = np.dtype(dtype).itemsize / itemsize
                 strides = [int(s*itemsize_ratio) for s in strides]
     elif order not in ["C", "F"]:

--- a/test/test_cumath.py
+++ b/test/test_cumath.py
@@ -242,5 +242,5 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec (sys.argv[1])
     else:
-        from py.test.cmdline import main
+        from pytest import main
         main([__file__])

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -961,5 +961,5 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec (sys.argv[1])
     else:
-        from py.test.cmdline import main
+        from pytest import main
         main([__file__])

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -1153,5 +1153,5 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec (sys.argv[1])
     else:
-        from py.test.cmdline import main
+        from pytest import main
         main([__file__])


### PR DESCRIPTION
Inspired by:
  https://lists.tiker.net/pipermail/pycuda/2016-December/004986.html
  https://gitlab.tiker.net/inducer/pycuda/merge_requests/1

I tried a new approach to supporting non-contiguous arrays in PyCUDA (could be ported to PyOpenCL somewhat easily I think).  The goals (some elicited by the above discussion and comments in the WIP) were:
- element-wise support for arbitrarily-strided arrays (including negative strides)
- backwards compatibility with current uses of ``get_elwise_module`` and ``get_elwise_range_module``
- limited performance impact on contiguous arrays
- avoid use of '*', '%', and '/' in calculating indices, at least within the element-wise loop

The only way I could think to support all those goals was to delay compilation (and source generation) to call-time, to take advantage of knowledge of input array strides.  Contiguous arrays get the kernels that PyCUDA has always given them, non-contiguous arrays get specialized kernels.  The nice thing about doing this is that the actual shape and strides can be sent as '#define's to aid compiler optimization (could even help with the contiguous kernels, though have not tried that).  The tricky thing about doing this is that some functions in the current implementation require the Module/Function before call-time, to get texrefs etc.  So I basically implemented a Proxy class for SourceModule, called ``DeferredSourceModule`` which also defers the generation of the values created by ``get_function()``, ``get_texref()``, etc. until call-time.

To make this all work, indexing (for non-contiguous arrays at least) for an array ``A`` needs to be ``A[A_i]``, rather than ``A[i]``.  If it detects matching contiguous arrays as inputs, then ``X_i`` is '#define'd to be ``i``, so kernels using the old method will still work (as long as the input arrays are contiguous and match in strides).  No regexes needed to transform the user-specified kernel fragments, it's all directed by the user.  Also, if you want to support non-contiguous arrays, you need to send the actual ``GPUArray`` objects, rather than their ``gpudata`` members to the call or prepare_ functions.

All existing tests succeed.  More would probably need to be added if it made sense to integrate this into PyCUDA.

Positive side-effects: ``GPUArray.get()``, ``GPUArray.set()`` and ``GPUArray.copy()`` now work for arbitrarily sliced/strided arrays.

The performance hit for contiguous arrays is around 15% for modest-sized arrays (i.e. the 1000x100 array tested by Keegan in the above discussion) and, looking at profiling output, I think the hit is due to detecting contiguity/order (in ``ElementwiseSourceModule.create_key()``).  This could probably be improved.  Performance for non-contiguous arrays is _infinitely_ better, given that they weren't supported before, but I've seen a 40% slowdown over the contiguous version for the ``b1[::2,:-1]**2`` test Keegan tried, due to the need to calculate indexes at each iteration of the loop.  It tries to do this in a smart way, by pre-calculating the per-thread step for each dimension, and only using division/modulo to calculate the starting indices for each thread before the loop.

Independently of whether these changes are merged in, I will continue to use and develop them to support some local needs, so comments are welcome.  I hope this is useful!
