### PR TITLE
Another attempt at supporting non-contiguous arrays

### DIFF
--- a/pycuda/cumath.py
+++ b/pycuda/cumath.py
@@ -42,7 +42,7 @@ def _make_unary_array_func(name):
 
         func = elementwise.get_unary_func_kernel(func_name, array.dtype)
         func.prepared_async_call(array._grid, array._block, stream,
-                array.gpudata, out.gpudata, array.mem_size)
+                array, out, array.mem_size)
 
         return out
     return f
@@ -77,7 +77,7 @@ def fmod(arg, mod, stream=None):
 
     func = elementwise.get_fmod_kernel()
     func.prepared_async_call(arg._grid, arg._block, stream,
-            arg.gpudata, mod.gpudata, result.gpudata, arg.mem_size)
+            arg, mod, result, arg.mem_size)
 
     return result
 
@@ -94,7 +94,7 @@ def frexp(arg, stream=None):
 
     func = elementwise.get_frexp_kernel()
     func.prepared_async_call(arg._grid, arg._block, stream,
-            arg.gpudata, sig.gpudata, expt.gpudata, arg.mem_size)
+            arg, sig, expt, arg.mem_size)
 
     return sig, expt
 
@@ -111,7 +111,7 @@ def ldexp(significand, exponent, stream=None):
 
     func = elementwise.get_ldexp_kernel()
     func.prepared_async_call(significand._grid, significand._block, stream,
-            significand.gpudata, exponent.gpudata, result.gpudata,
+            significand, exponent, result,
             significand.mem_size)
 
     return result
@@ -129,7 +129,7 @@ def modf(arg, stream=None):
 
     func = elementwise.get_modf_kernel()
     func.prepared_async_call(arg._grid, arg._block, stream,
-            arg.gpudata, intpart.gpudata, fracpart.gpudata,
+            arg, intpart, fracpart,
             arg.mem_size)
 
     return fracpart, intpart

--- a/pycuda/curandom.py
+++ b/pycuda/curandom.py
@@ -240,7 +240,7 @@ def rand(shape, dtype=np.float32, stream=None):
         raise NotImplementedError;
 
     func.prepared_async_call(result._grid, result._block, stream,
-            result.gpudata, np.random.randint(2**31-1), result.size)
+            result, np.random.randint(2**31-1), result.size)
 
     return result
 

--- a/pycuda/deferred.py
+++ b/pycuda/deferred.py
@@ -1,0 +1,511 @@
+"""
+This exports a "deferred" implementation of SourceModule, where compilation
+is delayed until call-time.  Several methods, like get_function(), return
+"deferred" values that are also only evaluated at call-time.
+"""
+
+from pycuda.tools import context_dependent_memoize
+from pycuda.compiler import compile, SourceModule
+import pycuda.driver
+
+import re
+
+class DeferredSource(object):
+    '''
+    Source generator that supports user-directed indentation, nesting
+    ``DeferredSource`` objects, indentation-aware string interpolation,
+    and deferred generation.
+    Use ``+=`` or ``add()`` to add source fragments as strings or
+    other ``DeferredSource`` objects, ``indent()`` or ``dedent()`` to
+    change base indentation, and ``__call__`` or ``generate()`` to
+    generate source.
+    
+    '''
+    def __init__(self, subsources=None, base_indent=0, indent_step=2):
+        self.base_indent = base_indent
+        self.indent_step = indent_step
+        if subsources is None:
+            subsources = []
+        self.subsources = subsources
+
+    def __str__(self):
+        return self.generate()
+
+    def __repr__(self):
+        return repr(self.__str__())
+
+    def __call__(self, indent=0, indent_first=True):
+        return self.generate(indent, indent_first)
+
+    def generate(self, indent=0, indent_first=True, get_list=False):
+        if get_list:
+            retval = []
+        else:
+            retval = ''
+        do_indent = not indent_first
+        for subindent, strip_space, subsource, format_dict in self.subsources:
+            if do_indent:
+                newindent = self.base_indent + indent + subindent
+            else:
+                newindent = 0
+            do_indent = True
+            if isinstance(subsource, DeferredSource):
+                retval = retval + subsource.generate(indent=(indent + subindent), get_list=get_list)
+                continue
+            lines = subsource.split("\n")
+            regex_space = re.compile(r"^(\s*)(.*?)(\s*)$")
+            regex_format = re.compile(r"%\(([^\)]*)\)([a-zA-Z])")
+            minstrip = None
+            newlines = []
+            for line in lines:
+                linelen = len(line)
+                space_match = regex_space.match(line)
+                end_leading_space = space_match.end(1)
+                begin_trailing_space = space_match.start(3)
+                if strip_space:
+                    if linelen == end_leading_space:
+                        # all space, ignore
+                        continue
+                    if minstrip is None or end_leading_space < minstrip:
+                        minstrip = end_leading_space
+                if not format_dict:
+                    newlines.append(line)
+                    continue
+                newlinelist = None
+                newline = ''
+                curpos = 0
+                matches = list(regex_format.finditer(line, end_leading_space))
+                nummatches = len(matches)
+                for match in matches:
+                    formatchar = match.group(2)
+                    name = match.group(1)
+                    matchstart = match.start()
+                    matchend = match.end()
+                    repl = format_dict.get(name, None)
+                    if repl is None:
+                        continue
+                    if (isinstance(repl, DeferredSource) and
+                        nummatches == 1 and
+                        matchstart == end_leading_space):
+                        # only one replacement, and only spaces preceding
+                        space = space_match.group(1)
+                        newlinelist = [ space + x
+                                        for x in repl.generate(get_list=True) ]
+                    else:
+                        newline = newline + line[curpos:matchstart]
+                        newline = newline + (('%' + formatchar) % (repl,))
+                    curpos = matchend
+                if newlinelist is None:
+                    newline = newline + line[curpos:]
+                    newlines.append(newline)
+                else:
+                    newlines.extend(newlinelist)
+                    newlines.append(line[curpos:])
+            indentstr = ' ' * (indent + subindent)
+            for i, line in enumerate(newlines):
+                line = indentstr + line[minstrip:]
+                newlines[i] = line
+            if get_list:
+                retval += newlines
+            else:
+                retval = retval + "\n".join(newlines) + "\n"
+        return retval
+
+    def indent(self, indent_step=None):
+        if indent_step is None:
+            indent_step = self.indent_step
+        self.base_indent += indent_step
+        return self
+
+    def dedent(self, indent_step=None):
+        if indent_step is None:
+            indent_step = self.indent_step
+        self.base_indent -= indent_step
+        return self
+
+    def format_dict(self, format_dict):
+        for subsource in self.subsources:
+            subsource[3] = format_dict
+        return self
+
+    def add(self, other, strip_space=True, format_dict=None):
+        self.subsources.append([self.base_indent, strip_space, other, format_dict])
+        return self
+
+    def __iadd__(self, other):
+        self.add(other)
+        return self
+
+    def __add__(self, other):
+        newgen = DeferredSource(subsources=self.subsources,
+                                base_indent=self.base_indent,
+                                indent_step=self.indent_step)
+        newgen.add(other)
+        return newgen
+
+class DeferredVal(object):
+    '''
+    This is an object that serves as a proxy to an as-yet undetermined
+    object, which is only known at the time when either ``_set_val()``
+    or ``_evalbase()`` is called.  Any calls to methods listed in the class
+    attribute ``_deferred_method_dict`` are queued until a call to
+    ``_eval()``, at which point ``_evalbase()`` is called (unless the value
+    has been already set by an earlier call to ``_evalbase()`` or
+    ``set_val()``), and then the queued method calls are executed, in order,
+    immediately on the new object.
+    This class must be subclassed, and the class attribute
+    ``_deferred_method_dict`` must contain a mapping from defer-able method
+    names to either ``DeferredVal``, None (same as ``DeferredVal``), or a
+    subclass, which when instantiated, will be assigned (with ``_set_val()``)
+    the return value of the method.
+    There are two ways to set the proxied object.  One is to set it
+    explicitly with ``_set_val(val)``.  The other is to override the method
+    ``_evalbase()`` which should return the new object, and will be called
+    by ``_eval()``.
+    '''
+    __unimpl = object()
+    _deferred_method_dict = None # must be set by subclass
+
+    def __init__(self):
+        self._val_available = False
+        self._val = None
+        self._deferred_method_calls = []
+
+    def _copy(self, retval=None):
+        if retval is None:
+            retval = self.__class__()
+        retval._val_available = self._val_available
+        retval._val = self._val
+        retval._deferred_method_calls = self._deferred_method_calls
+        return retval
+
+    def __repr__(self):
+        return self._repr(0)
+
+    def _repr(self, indent):
+        indentstr = " " * indent
+        retstrs = []
+        retstrs.append("")
+        retstrs.append("%s [" % (self.__class__,))
+        for dmc in self._deferred_method_calls:
+            (name, args, kwargs, retval) = dmc
+            retstrs.append("  method %s" % (repr(name),))
+            for arg in args:
+                if isinstance(arg, DeferredVal):
+                    retstrs.append("    deferred arg (id=%s)" % (id(arg),))
+                    retstrs.append(arg._repr(indent + 6))
+                else:
+                    retstrs.append("    arg %s" % (repr(arg),))
+            for kwname, arg in kwargs.items():
+                if isinstance(arg, DeferredVal):
+                    retstrs.append("    deferred kwarg %s (id=%s)" % (repr(kwname), id(arg)))
+                    retstrs.append(arg._repr(indent + 6))
+                else:
+                    retstrs.append("    kwarg %s=%s" % (kwname, repr(arg),))
+            retstrs.append("    deferred retval (id=%s)" % (id(retval),))
+        retstrs.append("]")
+        return "\n".join([(indentstr + retstr) for retstr in retstrs])
+
+    def _set_val(self, val):
+        self._val = val
+        self._val_available = True
+        self._eval_methods()
+        return val
+
+    def _evalbase(self, evalcont=None):
+        raise NotImplementedError()
+
+    def _eval_list(self, vals, evalcont=None):
+        newvals = []
+        for val in vals:
+            if isinstance(val, DeferredVal):
+                val = val._eval(evalcont=evalcont)
+            newvals.append(val)
+        return newvals
+
+    def _eval_dict(self, valsdict, evalcont=None):
+        newvalsdict = {}
+        for name, val in valsdict.items():
+            if isinstance(val, DeferredVal):
+                val = val._eval(evalcont=evalcont)
+            newvalsdict[name] = val
+        return newvalsdict
+
+    def _eval_methods(self, evalcont=None):
+        assert(self._val_available)
+        val = self._val
+        for op in self._deferred_method_calls:
+            (methodname, methodargs, methodkwargs, deferredretval) = op
+            methodargs = self._eval_list(methodargs, evalcont=evalcont)
+            methodkwargs = self._eval_dict(methodkwargs, evalcont=evalcont)
+            retval = getattr(val, methodname)(*methodargs, **methodkwargs)
+            deferredretval._set_val(retval)
+        self._deferred_method_calls = []
+
+    def _eval(self, evalcont=None):
+        if not self._val_available:
+            self._val = self._evalbase(evalcont=evalcont)
+            self._val_available = True
+            self._eval_methods(evalcont=evalcont)
+        return self._val
+
+    def _get_deferred_func(self, _name, _retval):
+        def _deferred_func(*args, **kwargs):
+            if not self._val_available:
+                self._deferred_method_calls.append((_name, args, kwargs, _retval))
+                return _retval
+            args = self._eval_list(args)
+            kwargs = self._eval_dict(kwargs)
+            return getattr(self._val, _name)(*args, **kwargs)
+        _deferred_func.__name__ = _name + ".deferred"
+        return _deferred_func
+
+    def __getattr__(self, name):
+        if self.__class__._deferred_method_dict is None:
+            raise Exception("DeferredVal must be subclassed and the class attribute _deferred_method_dict must be set to a valid dictionary!")
+        if self._val_available:
+            return getattr(self._val, name)
+        deferredclass = self.__class__._deferred_method_dict.get(name, self.__unimpl)
+        if deferredclass is not self.__unimpl:
+            if deferredclass is None:
+                deferredclass = DeferredVal
+            retval = deferredclass()
+            return self._get_deferred_func(name, retval)
+        raise AttributeError("no such attribute (yet): '%s'" % (name,))
+
+# we allow all math operators to be deferred
+_mathops = (
+    '__add__', '__sub__', '__mul__', '__floordiv__', '__mod__',
+    '__divmod__', '__pow__', '__lshift__', '__rshift__', '__and__',
+    '__xor__', '__or__', '__div__', '__truediv__', '__radd__', '__rsub__',
+    '__rmul__', '__rdiv__', '__rtruediv__', '__rfloordiv__', '__rmod__',
+    '__rdivmod__', '__rpow__', '__rlshift__', '__rrshift__', '__rand__',
+    '__rxor__', '__ror__', '__iadd__', '__isub__', '__imul__', '__idiv__',
+    '__itruediv__', '__ifloordiv__', '__imod__', '__ipow__', '__ilshift__',
+    '__irshift__', '__iand__', '__ixor__', '__ior__', '__pos__', '__abs__',
+    '__invert__', '__complex__', '__int__', '__long__', '__float__',
+    '__oct__', '__hex__', '__index__', '__coerce__')
+class DeferredNumeric(DeferredVal):
+    pass
+DeferredNumeric._deferred_method_dict = dict((x, DeferredNumeric)
+                                             for x in _mathops)
+def _get_deferred_attr_func(_name):
+    def _deferred_func(self, *args, **kwargs):
+        return self.__getattr__(_name)(*args, **kwargs)
+    _deferred_func.__name__ = _name
+    return _deferred_func
+for name in _mathops:
+    setattr(DeferredNumeric, name, _get_deferred_attr_func(name))
+
+class DeferredModuleCall(DeferredVal):
+    _deferred_method_dict = {}
+    def __init__(self, methodstr, *args, **kwargs):
+        super(DeferredModuleCall, self).__init__()
+        self._methodstr = methodstr
+        self._args = args
+        self._kwargs = kwargs
+
+    def _copy(self, retval=None):
+        if retval is None:
+            retval = self.__class__(self._methodstr, *self._args, **self._kwargs)
+        return super(DeferredModuleCall, self)._copy(retval=retval)
+
+    def _evalbase(self, evalcont):
+        # evalcont is the actual Module object
+        return getattr(evalcont, self._methodstr)(*self._args, **self._kwargs)
+
+class DeferredTexRef(DeferredModuleCall):
+    _deferred_method_dict = {
+        "set_array": None,
+        "set_address": DeferredNumeric,
+        "set_address_2d": None,
+        "set_format": None,
+        "set_address_mode": None,
+        "set_flags": None,
+        "get_address": DeferredNumeric,
+        "get_flags": DeferredNumeric,
+    }
+
+class DeferredFunction(object):
+    '''
+    This class is a pseudo-replacement of ``pycuda.driver.Function``,
+    but takes a ``DeferredSourceModule`` and a function name as an argument,
+    and queues any call to ``prepare()`` until call-time, at which time it
+    calls out to the ``DeferredSourceModule`` object do create the actual
+    Function before preparing (if necessary) and calling the underlying
+    kernel.  NOTE: you may now send the actual ``GPUArrays`` as arguments,
+    rather than their ``.gpudata`` members; this can be helpful to
+    dynamically create kernels.
+    '''
+    def __init__(self, deferredmod, funcname):
+        self._deferredmod = deferredmod
+        self._funcname = funcname
+        self._prepare_args = None
+
+        def get_unimplemented(_methodname):
+            def _unimplemented(self, _methodname=_methodname, *args, **kwargs):
+                raise NotImplementedError("%s does not implement method '%s'" % (type(self), _methodname,))
+            return _unimplemented
+
+        for meth_name in ["set_block_shape", "set_shared_size",
+                "param_set_size", "param_set", "param_seti", "param_setf",
+                "param_setv", "param_set_texref",
+                "launch", "launch_grid", "launch_grid_async"]:
+            setattr(self, meth_name, get_unimplemented(meth_name))
+
+    def _fix_texrefs(self, kwargs, mod):
+        texrefs = kwargs.get('texrefs', None)
+        if texrefs is not None:
+            kwargs = kwargs.copy()
+            newtexrefs = []
+            for texref in texrefs:
+                if isinstance(texref, DeferredVal):
+                    texref = texref._copy() # future calls may use different modules/functions
+                    texref = texref._eval(mod)
+                newtexrefs.append(texref)
+            kwargs['texrefs'] = newtexrefs
+        return kwargs
+
+    def __call__(self, *args, **kwargs):
+        block = kwargs.get('block', None)
+        if block is None or not isinstance(block, tuple) or len(block) != 3:
+            raise ValueError("keyword argument 'block' is required, and must be a 3-tuple of integers")
+        grid = kwargs.get('grid', (1,1))
+        mod, func = self._deferredmod._delayed_get_function(self._funcname, args, grid, block)
+        kwargs = self._fix_texrefs(kwargs, mod)
+        return func.__call__(*args, **kwargs)
+
+    def param_set_texref(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def prepare(self, *args, **kwargs):
+        self._prepare_args = (args, kwargs)
+        return self
+
+    def _do_delayed_prepare(self, mod, func):
+        if self._prepare_args is None:
+            raise Exception("prepared_*_call() requires that prepare() be called first")
+        (prepare_args, prepare_kwargs) = self._prepare_args
+        prepare_kwargs = self._fix_texrefs(prepare_kwargs, mod)
+        func.prepare(*prepare_args, **prepare_kwargs)
+
+    def _generic_prepared_call(self, funcmethodstr, funcmethodargs, funcargs, funckwargs):
+        grid = funcmethodargs[0]
+        block = funcmethodargs[1]
+        mod, func = self._deferredmod._delayed_get_function(self._funcname, funcargs, grid, block)
+        self._do_delayed_prepare(mod, func)
+        newfuncargs = [ getattr(arg, 'gpudata', arg) for arg in funcargs ]
+        fullargs = list(funcmethodargs)
+        fullargs.extend(newfuncargs)
+        return getattr(func, funcmethodstr)(*fullargs, **funckwargs)
+
+    def prepared_call(self, grid, block, *args, **kwargs):
+        return self._generic_prepared_call('prepared_call', (grid, block), args, kwargs)
+
+    def prepared_timed_call(self, grid, block, *args, **kwargs):
+        return self._generic_prepared_call('prepared_timed_call', (grid, block), args, kwargs)
+
+    def prepared_async_call(self, grid, block, stream, *args, **kwargs):
+        return self._generic_prepared_call('prepared_async_call', (grid, block, stream), args, kwargs)
+
+@context_dependent_memoize
+def _delayed_compile_aux(source, compileargs):
+    # re-convert any tuples to lists
+    newcompileargs = []
+    for i, arg in enumerate(compileargs):
+        if isinstance(arg, tuple):
+            arg = list(arg)
+        newcompileargs.append(arg)
+    cubin = compile(source, *newcompileargs)
+
+    from pycuda.driver import module_from_buffer
+    return module_from_buffer(cubin)
+
+class DeferredSourceModule(SourceModule):
+    '''
+    This is an abstract specialization of SourceModule which allows the
+    delay of creating the actual kernel source until call-time, at which
+    point the actual arguments are available and their characteristics can
+    be used to create specific kernels.
+    To support this, ``get_function()`` returns a ``DeferredFunction``
+    object which queues any calls to ``DeferredFunction.prepare()`` and
+    saves them until future calls to ``DeferredFunction.__call__()`` or
+    ``DeferredFunction.prepared_*_call()``.  NOTE: you may now send actual
+    ``GPUArrays`` to these functions rather their ``.gpudata`` members;
+    this can be helpful when creating dynamic kernels.
+    Likewise, ``get_global()``, ``get_texref()`` and ``get_surfref()``
+    return proxy objects that can be stored by ``DeferredFunction.prepare()``
+    and will only be evaluated at call-time.
+    This class must be subclassed and the function ``create_source(self,
+    grid, block, *args)`` must be overridden, returning the kernel source
+    (or ``DeferredSource`` object) that should be compiled.  ``grid``,
+    ``block``, and ``*args`` are the same arguments that were sent to the
+    ``DeferredFunction`` call functions above.
+    The function ``create_key(self, grid, block, *args)`` is always
+    called before ``create_source`` and the key returned is used to cache
+    any compiled functions.  Default return value of ``create_key()`` is
+    None, which means to use the function name and generated source as the
+    key.  The return value of ``create_key()`` must be usable as a hash
+    key.
+    '''
+    _cache = {}
+
+    def __init__(self, nvcc="nvcc", options=None, keep=False,
+            no_extern_c=False, arch=None, code=None, cache_dir=None,
+            include_dirs=[]):
+        self._arch = arch
+        # tuples below are so _compileargs can be used as a hash key
+        if options is not None:
+            options = tuple(options)
+        include_dirs = tuple(include_dirs)
+        self._compileargs = (nvcc, options, keep, no_extern_c,
+                             arch, code, cache_dir, include_dirs)
+
+    def _delayed_compile(self, source):
+        self._check_arch(self._arch)
+
+        return _delayed_compile_aux(source, self._compileargs)
+
+    def create_key(self, grid, block, *funcargs):
+        return None
+
+    def create_source(self, grid, block, *funcargs):
+        raise NotImplementedError("create_source must be overridden!")
+
+    def _delayed_get_function(self, funcname, funcargs, grid, block):
+        '''
+        If ``create_key()`` returns non-None, then it is used as the key
+        to cache compiled functions.  Otherwise the return value of
+        ``create_source()`` is used as the key.
+        '''
+        context = pycuda.driver.Context.get_current()
+        funccache = DeferredSourceModule._cache.get(context, None)
+        if funccache is None:
+            funccache = self._cache[context] = {}
+        key = self.create_key(grid, block, *funcargs)
+        funckey = (funcname, key)
+        if key is None or funckey not in funccache:
+            source = self.create_source(grid, block, *funcargs)
+            if isinstance(source, DeferredSource):
+                source = source.generate()
+            if key is None:
+                funckey = (funcname, source)
+        modfunc = funccache.get(funckey, None)
+        if modfunc is None:
+            module = self._delayed_compile(source)
+            func = module.get_function(funcname)
+            modfunc = funccache[funckey] = (module, func)
+        return modfunc
+
+    def get_function(self, name):
+        return DeferredFunction(self, name)
+
+    def get_global(self, name):
+        raise NotImplementedError("Deferred globals in element-wise kernels not supported yet")
+
+    def get_texref(self, name):
+        return DeferredTexRef('get_texref', name)
+
+    def get_surfref(self, name):
+        raise NotImplementedError("Deferred surfaces in element-wise kernels not supported yet")
+

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -119,9 +119,8 @@ class ElementwiseSourceModule(DeferredSourceModule):
         self._arraypairs = arraypairs
         self._arrayspecificinds = arrayspecificinds
 
-        key = repr(self._init_args)
-
         if contigmatch:
+            key = repr(self._init_args)
             return key
 
         # Arrays are not contiguous or different order
@@ -579,12 +578,8 @@ class ElementwiseKernel:
 
         for arg, arg_descr in zip(args, arguments):
             if isinstance(arg_descr, VectorArg):
-                if not arg.flags.forc:
-                    raise RuntimeError("elementwise kernel cannot "
-                            "deal with non-contiguous arrays")
-
                 vectors.append(arg)
-                invocation_args.append(arg.gpudata)
+                invocation_args.append(arg)
             else:
                 invocation_args.append(arg)
 
@@ -631,9 +626,9 @@ def get_take_kernel(dtype, idx_dtype, vec_count=1):
         "texture <%s, 1, cudaReadModeElementType> tex_src%d;" % (ctx["tex_tp"], i)
         for i in range(vec_count))
     body = (
-            ("%(idx_tp)s src_idx = idx[i];\n" % ctx)
+            ("%(idx_tp)s src_idx = idx[idx_i];\n" % ctx)
             + "\n".join(
-                "dest%d[i] = fp_tex1Dfetch(tex_src%d, src_idx);" % (i, i)
+                "dest%d[dest%d_i] = fp_tex1Dfetch(tex_src%d, src_idx);" % (i, i, i)
                 for i in range(vec_count)))
 
     mod = get_elwise_module(args, body, "take", preamble=preamble)
@@ -676,11 +671,12 @@ def get_take_put_kernel(dtype, idx_dtype, with_offsets, vec_count=1):
             return ("dest%d[dest_idx] = "
                     "fp_tex1Dfetch(tex_src%d, src_idx);" % (i, i))
 
-    body = (("%(idx_tp)s src_idx = gmem_src_idx[i];\n"
-                "%(idx_tp)s dest_idx = gmem_dest_idx[i];\n" % ctx)
+    body = (("%(idx_tp)s src_idx = gmem_src_idx[gmem_src_idx_i];\n"
+                "%(idx_tp)s dest_idx = gmem_dest_idx[gmem_dest_idx_i];\n" % ctx)
             + "\n".join(get_copy_insn(i) for i in range(vec_count)))
 
-    mod = get_elwise_module(args, body, "take_put", preamble=preamble)
+    mod = get_elwise_module(args, body, "take_put",
+                            preamble=preamble, shape_arg_index=0)
     func = mod.get_function("take_put")
     tex_src = [mod.get_texref("tex_src%d" % i) for i in range(vec_count)]
 
@@ -710,11 +706,12 @@ def get_put_kernel(dtype, idx_dtype, vec_count=1):
             ] + [ScalarArg(np.intp, "n")]
 
     body = (
-            "%(idx_tp)s dest_idx = gmem_dest_idx[i];\n" % ctx
-            + "\n".join("dest%d[dest_idx] = src%d[i];" % (i, i)
+            "%(idx_tp)s dest_idx = gmem_dest_idx[gmem_dest_idx_i];\n" % ctx
+            + "\n".join("dest%d[dest_idx] = src%d[src%d_i];" % (i, i, i)
                 for i in range(vec_count)))
 
-    func = get_elwise_module(args, body, "put").get_function("put")
+    func = get_elwise_module(args, body, "put",
+                             shape_arg_index=0).get_function("put")
     func.prepare("P"+(2*vec_count*"P")+np.dtype(np.uintp).char)
     return func
 
@@ -726,7 +723,7 @@ def get_copy_kernel(dtype_dest, dtype_src):
                 "tp_dest": dtype_to_ctype(dtype_dest),
                 "tp_src": dtype_to_ctype(dtype_src),
                 },
-            "dest[i] = src[i]",
+            "dest[dest_i] = src[src_i]",
             "copy")
 
 
@@ -758,13 +755,13 @@ def get_linear_combination_kernel(summand_descriptors,
             args.append(ScalarArg(scalar_dtype, "a%d" % i))
             args.append(VectorArg(vector_dtype, "x%d" % i))
 
-        summands.append("a%d*x%d[i]" % (i, i))
+        summands.append("a%d*x%d[x%d_i]" % (i, i, i))
 
     args.append(VectorArg(dtype_z, "z"))
     args.append(ScalarArg(np.uintp, "n"))
 
     mod = get_elwise_module(args,
-            "z[i] = " + " + ".join(summands),
+            "z[z_i] = " + " + ".join(summands),
             "linear_combination",
             preamble="\n".join(preamble),
             loop_prep=";\n".join(loop_prep))
@@ -785,7 +782,7 @@ def get_axpbyz_kernel(dtype_x, dtype_y, dtype_z):
                 "tp_y": dtype_to_ctype(dtype_y),
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
-            "z[i] = a*x[i] + b*y[i]",
+            "z[z_i] = a*x[x_i] + b*y[y_i]",
             "axpbyz")
 
 
@@ -796,7 +793,7 @@ def get_axpbz_kernel(dtype_x, dtype_z):
                 "tp_x": dtype_to_ctype(dtype_x),
                 "tp_z": dtype_to_ctype(dtype_z)
                 },
-            "z[i] = a * x[i] + b",
+            "z[z_i] = a * x[x_i] + b",
             "axpb")
 
 
@@ -808,7 +805,7 @@ def get_binary_op_kernel(dtype_x, dtype_y, dtype_z, operator):
                 "tp_y": dtype_to_ctype(dtype_y),
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
-            "z[i] = x[i] %s y[i]" % operator,
+            "z[z_i] = x[x_i] %s y[y_i]" % operator,
             "multiply")
 
 
@@ -819,7 +816,7 @@ def get_rdivide_elwise_kernel(dtype_x, dtype_z):
                 "tp_x": dtype_to_ctype(dtype_x),
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
-            "z[i] = y / x[i]",
+            "z[z_i] = y / x[x_i]",
             "divide_r")
 
 
@@ -831,7 +828,7 @@ def get_binary_func_kernel(func, dtype_x, dtype_y, dtype_z):
                 "tp_y": dtype_to_ctype(dtype_y),
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
-            "z[i] = %s(x[i], y[i])" % func,
+            "z[z_i] = %s(x[x_i], y[y_i])" % func,
             func+"_kernel")
 
 
@@ -843,7 +840,7 @@ def get_binary_func_scalar_kernel(func, dtype_x, dtype_y, dtype_z):
                 "tp_y": dtype_to_ctype(dtype_y),
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
-            "z[i] = %s(x[i], y)" % func,
+            "z[z_i] = %s(x[x_i], y)" % func,
             func+"_kernel")
 
 
@@ -867,7 +864,7 @@ def get_fill_kernel(dtype):
             "%(tp)s a, %(tp)s *z" % {
                 "tp": dtype_to_ctype(dtype),
                 },
-            "z[i] = a",
+            "z[z_i] = a",
             "fill")
 
 
@@ -877,7 +874,7 @@ def get_reverse_kernel(dtype):
             "%(tp)s *y, %(tp)s *z" % {
                 "tp": dtype_to_ctype(dtype),
                 },
-            "z[i] = y[n-1-i]",
+            "z[z_i] = y[n-1-y_i]",
             "reverse")
 
 
@@ -888,7 +885,7 @@ def get_real_kernel(dtype, real_dtype):
                 "tp": dtype_to_ctype(dtype),
                 "real_tp": dtype_to_ctype(real_dtype),
                 },
-            "z[i] = real(y[i])",
+            "z[z_i] = real(y[y_i])",
             "real")
 
 
@@ -899,7 +896,7 @@ def get_imag_kernel(dtype, real_dtype):
                 "tp": dtype_to_ctype(dtype),
                 "real_tp": dtype_to_ctype(real_dtype),
                 },
-            "z[i] = imag(y[i])",
+            "z[z_i] = imag(y[y_i])",
             "imag")
 
 
@@ -909,7 +906,7 @@ def get_conj_kernel(dtype):
             "%(tp)s *y, %(tp)s *z" % {
                 "tp": dtype_to_ctype(dtype),
                 },
-            "z[i] = pycuda::conj(y[i])",
+            "z[z_i] = pycuda::conj(y[y_i])",
             "conj")
 
 
@@ -919,7 +916,7 @@ def get_arange_kernel(dtype):
             "%(tp)s *z, %(tp)s start, %(tp)s step" % {
                 "tp": dtype_to_ctype(dtype),
                 },
-            "z[i] = start + i*step",
+            "z[z_i] = start + z_i*step",
             "arange")
 
 
@@ -934,7 +931,7 @@ def get_pow_kernel(dtype):
             "%(tp)s value, %(tp)s *y, %(tp)s *z" % {
                 "tp": dtype_to_ctype(dtype),
                 },
-            "z[i] = %s(y[i], value)" % func,
+            "z[z_i] = %s(y[y_i], value)" % func,
             "pow_method")
 
 
@@ -951,7 +948,7 @@ def get_pow_array_kernel(dtype_x, dtype_y, dtype_z):
                 "tp_y": dtype_to_ctype(dtype_y),
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
-            "z[i] = %s(x[i], y[i])" % func,
+            "z[z_i] = %s(x[x_i], y[y_i])" % func,
             "pow_method")
 
 
@@ -959,7 +956,7 @@ def get_pow_array_kernel(dtype_x, dtype_y, dtype_z):
 def get_fmod_kernel():
     return get_elwise_kernel(
             "float *arg, float *mod, float *z",
-            "z[i] = fmod(arg[i], mod[i])",
+            "z[z_i] = fmod(arg[arg_i], mod[mod_i])",
             "fmod_kernel")
 
 
@@ -967,7 +964,7 @@ def get_fmod_kernel():
 def get_modf_kernel():
     return get_elwise_kernel(
             "float *x, float *intpart ,float *fracpart",
-            "fracpart[i] = modf(x[i], &intpart[i])",
+            "fracpart[fracpart_i] = modf(x[x_i], &intpart[intpart_i])",
             "modf_kernel")
 
 
@@ -977,8 +974,8 @@ def get_frexp_kernel():
             "float *x, float *significand, float *exponent",
             """
                 int expt = 0;
-                significand[i] = frexp(x[i], &expt);
-                exponent[i] = expt;
+                significand[significand_i] = frexp(x[x_i], &expt);
+                exponent[exponent_i] = expt;
             """,
             "frexp_kernel")
 
@@ -987,7 +984,7 @@ def get_frexp_kernel():
 def get_ldexp_kernel():
     return get_elwise_kernel(
             "float *sig, float *expt, float *z",
-            "z[i] = ldexp(sig[i], int(expt[i]))",
+            "z[z_i] = ldexp(sig[sig_i], int(expt[expt_i]))",
             "ldexp_kernel")
 
 
@@ -1001,7 +998,7 @@ def get_unary_func_kernel(func_name, in_dtype, out_dtype=None):
                 "tp_in": dtype_to_ctype(in_dtype),
                 "tp_out": dtype_to_ctype(out_dtype),
                 },
-            "z[i] = %s(y[i])" % func_name,
+            "z[z_i] = %s(y[y_i])" % func_name,
             "%s_kernel" % func_name)
 
 
@@ -1013,7 +1010,7 @@ def get_if_positive_kernel(crit_dtype, dtype):
             VectorArg(dtype, "else_"),
             VectorArg(dtype, "result"),
             ],
-            "result[i] = crit[i] > 0 ? then_[i] : else_[i]",
+            "result[result_i] = crit[crit_i] > 0 ? then_[then__i] : else_[else__i]",
             "if_positive")
 
 
@@ -1025,5 +1022,5 @@ def get_scalar_op_kernel(dtype_x, dtype_y, operator):
                 "tp_y": dtype_to_ctype(dtype_y),
                 "tp_a": dtype_to_ctype(dtype_x),
                 },
-            "y[i] = x[i] %s a" % operator,
+            "y[y_i] = x[x_i] %s a" % operator,
             "scalarop_kernel")

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -36,92 +36,467 @@ from pycuda.tools import context_dependent_memoize
 import numpy as np
 from pycuda.tools import dtype_to_ctype, VectorArg, ScalarArg
 from pytools import memoize_method
+from pycuda.deferred import DeferredSourceModule, DeferredSource
+
+class ElementwiseSourceModule(DeferredSourceModule):
+    '''
+    This is a ``DeferredSourceModule`` which is backwards-compatible with the
+    original ``get_elwise_module`` and ``get_elwise_range_module`` (using
+    ``do_range=True``).  However, this class delays the compilation of
+    kernels until call-time.  If you send actual ``GPUArray`` arguments
+    (instead of their ``.gpudata`` members) when calling the methods
+    supported by the return value of ``get_function()``, then you get:
+      * support for array-specific flat indices (i.e. for input array ``z``,
+        you can index it as ``z[z_i]`` in addition to the old-style ``z[i]``)
+      * support for non-contiguous (and arbitrarily-strided) arrays, but
+        only if you use the array-specific indices above.
+    Array-specific flat indices only really work if all the arrays using them
+    are the same shape.  This shape is also used to optimize index
+    calculations.  By default, the shape is taken from the first argument
+    that is specified as a pointer/array, but you can override this by
+    sending ``shape_arg_index=N`` where ``N`` is the zero-based index of the
+    kernel argument whose shape should be used.
+    '''
+    def __init__(self, arguments, operation,
+                 name="kernel", preamble="", loop_prep="", after_loop="",
+                 do_range=False, shape_arg_index=None,
+                 debug=False,
+                 **compilekwargs):
+        super(ElementwiseSourceModule, self).__init__(**compilekwargs)
+        self._do_range = do_range
+        self._shape_arg_index = shape_arg_index
+        self._init_args = (tuple(arguments), operation,
+                           name, preamble, loop_prep, after_loop)
+        self._debug = debug
+
+    def create_key(self, grid, block, *args):
+        (arguments, operation,
+         funcname, preamble, loop_prep, after_loop) = self._init_args
+        shape_arg_index = self._shape_arg_index
+
+        # 'args' is the list of actual parameters being sent to the kernel
+        # 'arguments' is the list of argument descriptors (VectorArg, ScalarArg)
+
+        arraypairs = []
+        contigmatch = True
+        arrayspecificinds = True
+        shape = None
+        size = None
+        order = None
+        for i, argpair in enumerate(zip(args, arguments)):
+            arg, arg_descr = argpair
+            if isinstance(arg_descr, VectorArg):
+                # is a GPUArray/DeviceAllocation
+                arraypairs.append(argpair)
+                if not arrayspecificinds:
+                    continue
+                if not hasattr(arg, 'shape'):
+                    # At least one array argument is probably sent as a
+                    # GPUArray.gpudata rather than the GPUArray itself,
+                    # so disable array-specific indices -- caller is on
+                    # their own.
+                    arrayspecificinds = False
+                    continue
+                curshape = arg.shape
+                cursize = arg.size
+                curorder = 'N'
+                if arg.flags.f_contiguous:
+                    curorder = 'F'
+                elif arg.flags.c_contiguous:
+                    curorder = 'C'
+                if shape is None:
+                    shape = curshape
+                    size = cursize
+                    order = curorder
+                elif curorder == 'N' or order != curorder:
+                    contigmatch = False
+                elif shape_arg_index is None and shape != curshape:
+                    raise Exception("All input arrays to elementwise kernels must have the same shape, or you must specify the argument that has the canonical shape with shape_arg_index; found shapes %s and %s" % (shape, curshape))
+                if shape_arg_index == i:
+                    shape = curshape
+
+        self._contigmatch = contigmatch
+        self._arraypairs = arraypairs
+        self._arrayspecificinds = arrayspecificinds
+
+        key = repr(self._init_args)
+
+        if contigmatch:
+            return key
+
+        # Arrays are not contiguous or different order
+
+        if grid[1] != 1 or block[1] != 1 or block[2] != 1:
+            raise Exception("Grid (%s) and block (%s) specifications should have all '1' except in the first element" % (grid, block))
+
+        ndim = len(shape)
+        numthreads = block[0]
+
+        # Use index of minimum stride in first array as a hint on how to
+        # order the traversal of dimensions.  We could probably do something
+        # smarter, like tranposing/reshaping arrays if possible to maximize
+        # performance, but that is probably best done in a pre-processing step.
+        # Note that this could mess up custom indexing that assumes a
+        # particular traversal order, but in that case one should probably
+        # ensure that inputs have the same order, and explicitly send
+        # shape_arg_index to turn this off.
+        do_reverse = False
+        if (shape_arg_index is None and
+            np.argmin(np.abs(arraypairs[0][0].strides)) > ndim // 2):
+            print "traversing dimensions in reverse order"
+            # traverse dimensions in reverse order
+            do_reverse = True
+        if do_reverse:
+            shape = shape[::-1]
+        shapearr = np.array(shape)
+        block_step = np.array(shapearr)
+        tmp = numthreads
+        for dimnum in range(ndim):
+            newstep = tmp % block_step[dimnum]
+            tmp = tmp // block_step[dimnum]
+            block_step[dimnum] = newstep
+        arrayarginfos = []
+        for arg, arg_descr in arraypairs:
+            if do_reverse:
+                elemstrides = np.array(arg.strides[::-1]) // arg.itemsize
+            else:
+                elemstrides = np.array(arg.strides) // arg.itemsize
+            dimelemstrides = elemstrides * shapearr
+            blockelemstrides = elemstrides * block_step
+            arrayarginfos.append(
+                (arg_descr.name, tuple(elemstrides), tuple(dimelemstrides), tuple(blockelemstrides))
+            )
+
+        self._arrayarginfos = arrayarginfos
+        self._ndim = ndim
+        self._numthreads = numthreads
+        self._shape = shape
+        self._block_step = block_step
+
+        key = (self._init_args, grid, block, shape, tuple(self._arrayarginfos))
+
+        return key
+
+    def create_source(self, grid, block, *args):
+        # Precondition: create_key() must have been run with the same arguments
+
+        (arguments, operation,
+         funcname, preamble, loop_prep, after_loop) = self._init_args
+
+        contigmatch = self._contigmatch
+
+        if contigmatch:
+            arraypairs = self._arraypairs
+            arrayspecificinds = self._arrayspecificinds
+
+            indtype = 'unsigned'
+            if self._do_range:
+                indtype = 'long'
+
+            # All arrays are contiguous and same order (or we don't know and
+            # it's up to the caller to make sure it works)
+            if arrayspecificinds:
+                for arg, arg_descr in arraypairs:
+                    preamble = preamble + """
+                        #define %s_i i
+                    """ % (arg_descr.name,)
+            if self._do_range:
+                loop_body = """
+                  if (step < 0)
+                  {
+                    for (i = start + (cta_start + tid)*step;
+                      i > stop; i += total_threads*step)
+                    {
+                      %(operation)s;
+                    }
+                  }
+                  else
+                  {
+                    for (i = start + (cta_start + tid)*step;
+                      i < stop; i += total_threads*step)
+                    {
+                      %(operation)s;
+                    }
+                  }
+                """ % {
+                    "operation": operation,
+                }
+            else:
+                loop_body = """
+                  for (i = cta_start + tid; i < n; i += total_threads)
+                  {
+                    %(operation)s;
+                  }
+                """ % {
+                    "operation": operation,
+                }
+
+            return """
+                #include <pycuda-complex.hpp>
+
+                %(preamble)s
+
+                __global__ void %(name)s(%(arguments)s)
+                {
+                  unsigned tid = threadIdx.x;
+                  unsigned total_threads = gridDim.x*blockDim.x;
+                  unsigned cta_start = blockDim.x*blockIdx.x;
+
+                  %(indtype)s i;
+
+                  %(loop_prep)s;
+
+                  %(loop_body)s;
+
+                  %(after_loop)s;
+                }
+                """ % {
+                    "arguments": ", ".join(arg.declarator() for arg in arguments),
+                    "name": funcname,
+                    "preamble": preamble,
+                    "loop_prep": loop_prep,
+                    "after_loop": after_loop,
+                    "loop_body": loop_body,
+                    "indtype": indtype,
+                }
+
+        # Arrays are not contiguous or different order
+
+        arrayarginfos = self._arrayarginfos
+        ndim = self._ndim
+        numthreads = self._numthreads
+        shape = self._shape
+        block_step = self._block_step
+
+        arraynames = [ x[0] for x in arrayarginfos ]
+
+        defines = DeferredSource()
+        decls = DeferredSource()
+        loop_preop = DeferredSource()
+        loop_inds_calc = DeferredSource()
+        loop_inds_inc = DeferredSource()
+        loop_body = DeferredSource()
+
+        for dimnum in range(ndim):
+            defines += """
+                #define SHAPE_%d %d
+                #define BLOCK_STEP_%d %d
+            """ % (dimnum, shape[dimnum],
+                   dimnum, block_step[dimnum])
+            for name, elemstrides, dimelemstrides, blockelemstrides in arrayarginfos:
+                basename = "%s_%d" % (name, dimnum)
+                defines += """
+                    #define ELEMSTRIDE_%s_%d %d
+                    #define DIMELEMSTRIDE_%s_%d %d
+                    #define BLOCKELEMSTRIDE_%s_%d %d
+                """ % (name, dimnum, elemstrides[dimnum],
+                       name, dimnum, dimelemstrides[dimnum],
+                       name, dimnum, blockelemstrides[dimnum])
+
+        decls += """
+            unsigned GLOBAL_i = cta_start + tid;
+        """
+        for name in arraynames:
+            decls += """
+                long %s_i = 0;
+            """ % (name,)
+        for dimnum in range(ndim):
+            decls += """
+                long INDEX_%d;
+            """ % (dimnum,)
+
+        loop_inds_calc += """
+            unsigned int TMP_GLOBAL_i = GLOBAL_i;
+        """
+        for dimnum in range(ndim):
+            loop_inds_calc += """
+                INDEX_%d = TMP_GLOBAL_i %% SHAPE_%d;
+                TMP_GLOBAL_i = TMP_GLOBAL_i / SHAPE_%d;
+            """ % (dimnum, dimnum,
+                   dimnum)
+
+            for name in arraynames:
+                loop_inds_calc += """
+                    %s_i += INDEX_%d * ELEMSTRIDE_%s_%d;
+                """ % (name, dimnum, name, dimnum)
+
+        for dimnum in range(ndim):
+            loop_inds_inc += """
+                    INDEX_%d += BLOCK_STEP_%d;
+            """ % (dimnum, dimnum)
+            for name in arraynames:
+                loop_inds_inc += """
+                    %s_i += BLOCKELEMSTRIDE_%s_%d;
+                """ % (name, name, dimnum)
+            if dimnum < ndim - 1:
+                loop_inds_inc += """
+                    if (INDEX_%d > SHAPE_%d) {
+                """ % (dimnum, dimnum)
+                loop_inds_inc.indent()
+                loop_inds_inc += """
+                      INDEX_%d -= SHAPE_%d;
+                      INDEX_%d ++;
+                """ % (dimnum, dimnum,
+                       dimnum + 1)
+                for name in arraynames:
+                    loop_inds_inc += """
+                      %s_i += ELEMSTRIDE_%s_%d - DIMELEMSTRIDE_%s_%d;
+                    """ % (name, name, dimnum + 1, name, dimnum)
+                loop_inds_inc.dedent()
+                loop_inds_inc += """
+                    }
+                """
+
+        if self._debug:
+            preamble += """
+                #include <stdio.h>
+            """
+            loop_inds_calc += """
+                if (cta_start == 0 && tid == 0) {
+            """
+            loop_inds_calc.indent()
+            loop_inds_calc += r"""
+                printf("=======================\n");
+                printf("CALLING FUNC %s\n");
+                printf("N=%%u\n", (unsigned int)n);
+            """ % (funcname,)
+            for name, elemstrides, dimelemstrides, blockelemstrides in arrayarginfos:
+                loop_inds_calc += r"""
+                    printf("(%s) %s: ptr=0x%%lx maxoffset(elems)=%s\n", (unsigned long)%s);
+                """ % (funcname, name, np.sum((np.array(shape) - 1) * np.array(elemstrides)), name)
+            loop_inds_calc.dedent()
+            loop_inds_calc += """
+                }
+            """
+            indtest = DeferredSource()
+            for name in arraynames:
+                indtest += r"""
+                    if (%s_i > %s || %s_i < 0) {
+                """ % (name, np.sum((np.array(shape) - 1) * np.array(elemstrides)), name)
+                indtest.indent()
+                indtest += r"""
+                        printf("cta_start=%%d tid=%%d GLOBAL_i=%%d %s_i=%%d\n", cta_start, tid, GLOBAL_i, %s_i);
+                        break;
+                """ % (name, name)
+                indtest.dedent()
+                indtest += """
+                    }
+                """
+            loop_preop = indtest + loop_preop
+            after_loop += r"""
+                if (cta_start == 0 && tid == 0) {
+                    printf("DONE CALLING FUNC %s\n");
+                    printf("-----------------------\n");
+                }
+            """ % (funcname,)
+
+        if self._do_range:
+            loop_body.add("""
+              if (step < 0)
+              {
+                for (/*void*/; GLOBAL_i > stop; GLOBAL_i += total_threads*step)
+                {
+                  %(loop_preop)s;
+
+                  %(operation)s;
+
+                  %(loop_inds_inc)s;
+                }
+              }
+              else
+              {
+                for (/*void*/; GLOBAL_i < stop; GLOBAL_i += total_threads*step)
+                {
+                  %(loop_preop)s;
+
+                  %(operation)s;
+
+                  %(loop_inds_inc)s;
+                }
+              }
+            """, format_dict={
+                "loop_preop": loop_preop,
+                "operation": operation,
+                "loop_inds_inc": loop_inds_inc,
+            })
+        else:
+            loop_body.add("""
+              for (/*void*/; GLOBAL_i < n; GLOBAL_i += total_threads)
+              {
+                %(loop_preop)s;
+
+                %(operation)s;
+
+                %(loop_inds_inc)s;
+              }
+            """, format_dict={
+                "loop_preop": loop_preop,
+                "operation": operation,
+                "loop_inds_inc": loop_inds_inc,
+            })
+
+        source = DeferredSource()
+
+        source.add("""
+            #include <pycuda-complex.hpp>
+            #include <stdio.h>
+
+            %(defines)s
+
+            %(preamble)s
+
+            __global__ void %(name)s(%(arguments)s)
+            {
+
+              unsigned tid = threadIdx.x;
+              unsigned total_threads = gridDim.x*blockDim.x;
+              unsigned cta_start = blockDim.x*blockIdx.x;
+
+              %(decls)s
+
+              %(loop_prep)s;
+
+              %(loop_inds_calc)s;
+
+              %(loop_body)s;
+
+              %(after_loop)s;
+            }
+            """, format_dict={
+                "arguments": ", ".join(arg.declarator() for arg in arguments),
+                "name": funcname,
+                "preamble": preamble,
+                "loop_prep": loop_prep,
+                "after_loop": after_loop,
+                "defines": defines,
+                "decls": decls,
+                "loop_inds_calc": loop_inds_calc,
+                "loop_body": loop_body,
+            })
+
+        return source
 
 
 def get_elwise_module(arguments, operation,
         name="kernel", keep=False, options=None,
-        preamble="", loop_prep="", after_loop=""):
-    from pycuda.compiler import SourceModule
-    return SourceModule("""
-        #include <pycuda-complex.hpp>
-
-        %(preamble)s
-
-        __global__ void %(name)s(%(arguments)s)
-        {
-
-          unsigned tid = threadIdx.x;
-          unsigned total_threads = gridDim.x*blockDim.x;
-          unsigned cta_start = blockDim.x*blockIdx.x;
-          unsigned i;
-
-          %(loop_prep)s;
-
-          for (i = cta_start + tid; i < n; i += total_threads)
-          {
-            %(operation)s;
-          }
-
-          %(after_loop)s;
-        }
-        """ % {
-            "arguments": ", ".join(arg.declarator() for arg in arguments),
-            "operation": operation,
-            "name": name,
-            "preamble": preamble,
-            "loop_prep": loop_prep,
-            "after_loop": after_loop,
-            },
-        options=options, keep=keep)
-
+        preamble="", loop_prep="", after_loop="",
+        **kwargs):
+    return ElementwiseSourceModule(arguments, operation,
+                                   name=name, preamble=preamble,
+                                   loop_prep=loop_prep, after_loop=after_loop,
+                                   keep=keep, options=options,
+                                   **kwargs)
 
 def get_elwise_range_module(arguments, operation,
         name="kernel", keep=False, options=None,
-        preamble="", loop_prep="", after_loop=""):
-    from pycuda.compiler import SourceModule
-    return SourceModule("""
-        #include <pycuda-complex.hpp>
-
-        %(preamble)s
-
-        __global__ void %(name)s(%(arguments)s)
-        {
-          unsigned tid = threadIdx.x;
-          unsigned total_threads = gridDim.x*blockDim.x;
-          unsigned cta_start = blockDim.x*blockIdx.x;
-          long i;
-
-          %(loop_prep)s;
-
-          if (step < 0)
-          {
-            for (i = start + (cta_start + tid)*step;
-              i > stop; i += total_threads*step)
-            {
-              %(operation)s;
-            }
-          }
-          else
-          {
-            for (i = start + (cta_start + tid)*step;
-              i < stop; i += total_threads*step)
-            {
-              %(operation)s;
-            }
-          }
-
-          %(after_loop)s;
-        }
-        """ % {
-            "arguments": ", ".join(arg.declarator() for arg in arguments),
-            "operation": operation,
-            "name": name,
-            "preamble": preamble,
-            "loop_prep": loop_prep,
-            "after_loop": after_loop,
-            },
-        options=options, keep=keep)
-
+        preamble="", loop_prep="", after_loop="",
+        **kwargs):
+    return ElementwiseSourceModule(arguments, operation,
+                                   name=name, preamble=preamble,
+                                   loop_prep=loop_prep, after_loop=after_loop,
+                                   keep=keep, options=options,
+                                   do_range=True,
+                                   **kwargs)
 
 def get_elwise_kernel_and_types(arguments, operation,
         name="kernel", keep=False, options=None, use_range=False, **kwargs):

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -806,7 +806,7 @@ def get_binary_op_kernel(dtype_x, dtype_y, dtype_z, operator):
                 "tp_z": dtype_to_ctype(dtype_z),
                 },
             "z[z_i] = x[x_i] %s y[y_i]" % operator,
-            "multiply")
+            "binary_op")
 
 
 @context_dependent_memoize

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -912,7 +912,11 @@ class GPUArray(object):
                 strides=tuple(new_strides))
 
     def __setitem__(self, index, value):
-        _memcpy_discontig(self[index], value)
+        if isinstance(value, GPUArray) or isinstance(value, np.ndarray):
+            return _memcpy_discontig(self[index], value)
+
+        # Let's assume it's a scalar
+        self[index].fill(value)
 
     # }}}
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -118,23 +118,15 @@ def splay(n, dev=None):
 
 def _make_binary_op(operator):
     def func(self, other):
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         if isinstance(other, GPUArray):
             assert self.shape == other.shape
-
-            if not other.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
 
             result = self._new_like_me()
             func = elementwise.get_binary_op_kernel(
                     self.dtype, other.dtype, result.dtype,
                     operator)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, other.gpudata, result.gpudata,
+                    self, other, result,
                     self.mem_size)
 
             return result
@@ -143,7 +135,7 @@ def _make_binary_op(operator):
             func = elementwise.get_scalar_op_kernel(
                     self.dtype, result.dtype, operator)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, other, result.gpudata,
+                    self, other, result,
                     self.mem_size)
             return result
 
@@ -300,47 +292,36 @@ class GPUArray(object):
         """Compute ``out = selffac * self + otherfac*other``,
         where `other` is a vector.."""
         assert self.shape == other.shape
-        if not self.flags.forc or not other.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
 
         func = elementwise.get_axpbyz_kernel(self.dtype, other.dtype, out.dtype)
 
         if add_timer is not None:
             add_timer(3*self.size, func.prepared_timed_call(self._grid,
-                selffac, self.gpudata, otherfac, other.gpudata,
-                out.gpudata, self.mem_size))
+                selffac, self, otherfac, other,
+                out, self.mem_size))
         else:
             func.prepared_async_call(self._grid, self._block, stream,
-                    selffac, self.gpudata, otherfac, other.gpudata,
-                    out.gpudata, self.mem_size)
+                    selffac, self, otherfac, other,
+                    out, self.mem_size)
 
         return out
 
     def _axpbz(self, selffac, other, out, stream=None):
         """Compute ``out = selffac * self + other``, where `other` is a scalar."""
 
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         func = elementwise.get_axpbz_kernel(self.dtype, out.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                selffac, self.gpudata,
-                other, out.gpudata, self.mem_size)
+                selffac, self,
+                other, out, self.mem_size)
 
         return out
 
     def _elwise_multiply(self, other, out, stream=None):
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         func = elementwise.get_binary_op_kernel(self.dtype, other.dtype,
                 out.dtype, "*")
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, other.gpudata,
-                out.gpudata, self.mem_size)
+                self, other,
+                out, self.mem_size)
 
         return out
 
@@ -350,31 +331,23 @@ class GPUArray(object):
            y = n / self
         """
 
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         func = elementwise.get_rdivide_elwise_kernel(self.dtype, out.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, other,
-                out.gpudata, self.mem_size)
+                self, other,
+                out, self.mem_size)
 
         return out
 
     def _div(self, other, out, stream=None):
         """Divides an array by another array."""
 
-        if not self.flags.forc or not other.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         assert self.shape == other.shape
 
         func = elementwise.get_binary_op_kernel(self.dtype, other.dtype,
                 out.dtype, "/")
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, other.gpudata,
-                out.gpudata, self.mem_size)
+                self, other,
+                out, self.mem_size)
 
         return out
 
@@ -554,7 +527,7 @@ class GPUArray(object):
         """fills the array with the specified value"""
         func = elementwise.get_fill_kernel(self.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                value, self.gpudata, self.mem_size)
+                value, self, self.mem_size)
 
         return self
 
@@ -640,7 +613,7 @@ class GPUArray(object):
                 out_dtype=out_dtype)
 
         func.prepared_async_call(self._grid, self._block, None,
-                self.gpudata, result.gpudata, self.mem_size)
+                self, result, self.mem_size)
 
         return result
 
@@ -651,10 +624,6 @@ class GPUArray(object):
         """
 
         if isinstance(other, GPUArray):
-            if not self.flags.forc or not other.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
-
             assert self.shape == other.shape
 
             if new:
@@ -666,22 +635,18 @@ class GPUArray(object):
                     self.dtype, other.dtype, result.dtype)
 
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, other.gpudata, result.gpudata,
+                    self, other, result,
                     self.mem_size)
 
             return result
         else:
-            if not self.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
-
             if new:
                 result = self._new_like_me()
             else:
                 result = self
             func = elementwise.get_pow_kernel(self.dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    other, self.gpudata, result.gpudata,
+                    other, self, result,
                     self.mem_size)
 
             return result
@@ -713,24 +678,16 @@ class GPUArray(object):
         as one-dimensional.
         """
 
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         result = self._new_like_me()
 
         func = elementwise.get_reverse_kernel(self.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                self.gpudata, result.gpudata,
+                self, result,
                 self.mem_size)
 
         return result
 
     def astype(self, dtype, stream=None):
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
-
         if dtype == self.dtype:
             return self.copy()
 
@@ -738,7 +695,7 @@ class GPUArray(object):
 
         func = elementwise.get_copy_kernel(dtype, self.dtype)
         func.prepared_async_call(self._grid, self._block, stream,
-                result.gpudata, self.gpudata,
+                result, self,
                 self.mem_size)
 
         return result
@@ -750,9 +707,6 @@ class GPUArray(object):
         order = kwargs.pop("order", "C")
 
         # TODO: add more error-checking, perhaps
-        if not self.flags.forc:
-            raise RuntimeError("only contiguous arrays may "
-                    "be used as arguments to this operation")
 
         if isinstance(shape[0], tuple) or isinstance(shape[0], list):
             shape = tuple(shape[0])
@@ -970,15 +924,11 @@ class GPUArray(object):
         if issubclass(dtype.type, np.complexfloating):
             from pytools import match_precision
             real_dtype = match_precision(np.dtype(np.float64), dtype)
-            if self.flags.f_contiguous:
-                order = "F"
-            else:
-                order = "C"
-            result = self._new_like_me(dtype=real_dtype, order=order)
+            result = self._new_like_me(dtype=real_dtype)
 
             func = elementwise.get_real_kernel(dtype, real_dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, result.gpudata,
+                    self, result,
                     self.mem_size)
 
             return result
@@ -989,21 +939,13 @@ class GPUArray(object):
     def imag(self):
         dtype = self.dtype
         if issubclass(self.dtype.type, np.complexfloating):
-            if not self.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
-
             from pytools import match_precision
             real_dtype = match_precision(np.dtype(np.float64), dtype)
-            if self.flags.f_contiguous:
-                order = "F"
-            else:
-                order = "C"
-            result = self._new_like_me(dtype=real_dtype, order=order)
+            result = self._new_like_me(dtype=real_dtype)
 
             func = elementwise.get_imag_kernel(dtype, real_dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, result.gpudata,
+                    self, result,
                     self.mem_size)
 
             return result
@@ -1013,19 +955,11 @@ class GPUArray(object):
     def conj(self):
         dtype = self.dtype
         if issubclass(self.dtype.type, np.complexfloating):
-            if not self.flags.forc:
-                raise RuntimeError("only contiguous arrays may "
-                        "be used as arguments to this operation")
-
-            if self.flags.f_contiguous:
-                order = "F"
-            else:
-                order = "C"
-            result = self._new_like_me(order=order)
+            result = self._new_like_me()
 
             func = elementwise.get_conj_kernel(dtype)
             func.prepared_async_call(self._grid, self._block, None,
-                    self.gpudata, result.gpudata,
+                    self, result,
                     self.mem_size)
 
             return result
@@ -1219,7 +1153,7 @@ def arange(*args, **kwargs):
 
     func = elementwise.get_arange_kernel(dtype)
     func.prepared_async_call(result._grid, result._block, kwargs.get("stream"),
-            result.gpudata, start, step, size)
+            result, start, step, size)
 
     return result
 
@@ -1244,7 +1178,7 @@ def _flip_negative_strides(arrays):
         stride_sign = t[1]
         if len(arrays) > 1:
             if not np.all(t[2:] == stride_sign):
-                raise ValueError("found differing signs in dimension %d: %s" % (axis, t[1:]))
+                raise ValueError("found differing signs in strides for dimension %d (strides for all arrays: %s)" % (axis, [x.strides for x in arrays]))
         if stride_sign == -1:
             if slicer is None:
                 slicer = [slice(None)] * ndim
@@ -1425,7 +1359,7 @@ def take(a, indices, out=None, stream=None):
     a.bind_to_texref_ext(tex_src[0], allow_double_hack=True, allow_complex_hack=True)
 
     func.prepared_async_call(out._grid, out._block, stream,
-            indices.gpudata, out.gpudata, indices.size)
+            indices, out, indices.size)
 
     return out
 
@@ -1467,8 +1401,8 @@ def multi_take(arrays, indices, out=None, stream=None):
             a.bind_to_texref_ext(tex_src[i], allow_double_hack=True)
 
         func.prepared_async_call(indices._grid, indices._block, stream,
-                indices.gpudata,
-                *([o.gpudata for o in out[chunk_slice]]
+                indices,
+                *([o for o in out[chunk_slice]]
                     + [indices.size]))
 
     return out
@@ -1532,8 +1466,8 @@ def multi_take_put(arrays, dest_indices, src_indices, dest_shape=None,
             a.bind_to_texref_ext(src_tr, allow_double_hack=True)
 
         func.prepared_async_call(src_indices._grid,  src_indices._block, stream,
-                dest_indices.gpudata, src_indices.gpudata,
-                *([o.gpudata for o in out[chunk_slice]]
+                dest_indices, src_indices,
+                *([o for o in out[chunk_slice]]
                     + src_offsets_list[chunk_slice]
                     + [src_indices.size]))
 
@@ -1577,9 +1511,9 @@ def multi_put(arrays, dest_indices, dest_shape=None, out=None, stream=None):
             func = make_func_for_chunk_size(vec_count-start_i)
 
         func.prepared_async_call(dest_indices._grid, dest_indices._block, stream,
-                dest_indices.gpudata,
-                *([o.gpudata for o in out[chunk_slice]]
-                    + [i.gpudata for i in arrays[chunk_slice]]
+                dest_indices,
+                *([o for o in out[chunk_slice]]
+                    + [i for i in arrays[chunk_slice]]
                     + [dest_indices.size]))
 
     return out
@@ -1631,7 +1565,7 @@ def if_positive(criterion, then_, else_, out=None, stream=None):
         out = empty_like(then_)
 
     func.prepared_async_call(criterion._grid, criterion._block, stream,
-            criterion.gpudata, then_.gpudata, else_.gpudata, out.gpudata,
+            criterion, then_, else_, out,
             criterion.size)
 
     return out
@@ -1646,14 +1580,14 @@ def _make_binary_minmax_func(which):
                     a.dtype, b.dtype, out.dtype, use_scalar=False)
 
             func.prepared_async_call(a._grid, a._block, stream,
-                    a.gpudata, b.gpudata, out.gpudata, a.size)
+                    a, b, out, a.size)
         elif isinstance(a, GPUArray):
             if out is None:
                 out = empty_like(a)
             func = elementwise.get_binary_minmax_kernel(which,
                     a.dtype, a.dtype, out.dtype, use_scalar=True)
             func.prepared_async_call(a._grid, a._block, stream,
-                    a.gpudata, b, out.gpudata, a.size)
+                    a, b, out, a.size)
         else:  # assuming b is a GPUArray
             if out is None:
                 out = empty_like(b)
@@ -1661,7 +1595,7 @@ def _make_binary_minmax_func(which):
                     b.dtype, b.dtype, out.dtype, use_scalar=True)
             # NOTE: we switch the order of a and b here!
             func.prepared_async_call(b._grid, b._block, stream,
-                    b.gpudata, a, out.gpudata, b.size)
+                    b, a, out, b.size)
         return out
     return f
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -1034,10 +1034,10 @@ def _array_like_helper(other_ary, dtype, order):
             order = "F"
         else:
             # array_like routines only return positive strides
-            strides = [np.abs(s) for s in other_ary.strides]
+            _, strides, _ = _compact_positive_strides(other_ary)
             if dtype is not None and dtype != other_ary.dtype:
                 # scale strides by itemsize when dtype is not the same
-                itemsize = other_ary.nbytes // other_ary.size
+                itemsize = other_ary.dtype.itemsize
                 itemsize_ratio = np.dtype(dtype).itemsize / itemsize
                 strides = [int(s*itemsize_ratio) for s in strides]
     elif order not in ["C", "F"]:

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -246,13 +246,14 @@ class GPUArray(object):
         return self.set(ary, async=True, stream=stream)
 
     def get(self, ary=None, pagelocked=False, async=False, stream=None):
+        slicer = None
         if ary is None:
             if pagelocked:
                 ary = drv.pagelocked_empty(self.shape, self.dtype)
             else:
                 ary = np.empty(self.shape, self.dtype)
 
-            strides = _compact_strides(self)
+            self, strides, slicer = _compact_positive_strides(self)
             ary = _as_strided(ary, strides=strides)
         else:
             if self.size != ary.size:
@@ -269,13 +270,15 @@ class GPUArray(object):
 
         if self.size:
             _memcpy_discontig(ary, self, async=async, stream=stream)
+        if slicer:
+            ary = ary[slicer]
         return ary
 
     def get_async(self, stream=None, ary=None):
         return self.get(ary=ary, async=True, stream=stream)
 
-    def copy(self):
-        new = GPUArray(self.shape, self.dtype, self.allocator)
+    def copy(self, order="K"):
+        new = self._new_like_me(order=order)
         _memcpy_discontig(new, self)
         return new
 
@@ -375,15 +378,52 @@ class GPUArray(object):
 
         return out
 
-    def _new_like_me(self, dtype=None, order="C"):
-        strides = None
+    def _new_like_me(self, dtype=None, order="K"):
+        slicer, selflist = _flip_negative_strides((self,))
+        self = selflist[0]
+        ndim = self.ndim
+        shape = self.shape
+        mystrides = self.strides
+        mydtype = self.dtype
+        myitemsize = mydtype.itemsize
         if dtype is None:
-            dtype = self.dtype
-        if dtype == self.dtype:
-            strides = self.strides
-
-        return self.__class__(self.shape, dtype,
-                allocator=self.allocator, strides=strides, order=order)
+            dtype = mydtype
+        else:
+            dtype = np.dtype(dtype)
+        itemsize = dtype.itemsize
+        if order == "K":
+            if self.flags.c_contiguous:
+                order = "C"
+            elif self.flags.f_contiguous:
+                order = "F"
+        if order == "C":
+            newstrides = _c_contiguous_strides(itemsize, shape)
+        elif order == "F":
+            newstrides = _f_contiguous_strides(itemsize, shape)
+        else:
+            maxstride = mystrides[0]
+            maxstrideind = 0
+            for i in range(1, ndim):
+                curstride = mystrides[i]
+                if curstride > maxstride:
+                    maxstrideind = i
+                    maxstride = curstride
+            mymaxoffset = (maxstride / myitemsize) * shape[maxstrideind]
+            if mymaxoffset <= self.size:
+                # it's probably safe to just allocate and pass strides
+                # XXX (do we need to calculate full offset for [-1,-1,-1...]?)
+                newstrides = tuple((x // myitemsize) * itemsize for x in mystrides)
+            else:
+                # just punt and choose something close
+                if ndim > 1 and maxstrideind == 0:
+                    newstrides = _c_contiguous_strides(itemsize, shape)
+                else:
+                    newstrides = _f_contiguous_strides(itemsize, shape)
+        retval = self.__class__(shape, dtype,
+                     allocator=self.allocator, strides=newstrides)
+        if slicer:
+            retval = retval[slicer]
+        return retval
 
     # operators ---------------------------------------------------------------
     def mul_add(self, selffac, other, otherfac, add_timer=None, stream=None):
@@ -1012,15 +1052,21 @@ class GPUArray(object):
 
 def to_gpu(ary, allocator=drv.mem_alloc):
     """converts a numpy array to a GPUArray"""
-    result = GPUArray(ary.shape, ary.dtype, allocator, strides=_compact_strides(ary))
+    ary, newstrides, slicer = _compact_positive_strides(ary)
+    result = GPUArray(ary.shape, ary.dtype, allocator, strides=newstrides)
     result.set(ary)
+    if slicer:
+        result = result[slicer]
     return result
 
 
 def to_gpu_async(ary, allocator=drv.mem_alloc, stream=None):
     """converts a numpy array to a GPUArray"""
-    result = GPUArray(ary.shape, ary.dtype, allocator, strides=_compact_strides(ary))
+    ary, newstrides, slicer = _compact_positive_strides(ary)
+    result = GPUArray(ary.shape, ary.dtype, allocator, strides=newstrides)
     result.set_async(ary, stream)
+    if slicer:
+        result = result[slicer]
     return result
 
 
@@ -1180,8 +1226,41 @@ def arange(*args, **kwargs):
 # }}}
 
 
-def _compact_strides(a):
-    # Compute strides to have same order as self, but packed
+def _flip_negative_strides(arrays):
+    # If arrays have negative strides, flip them.  Return a list
+    # ``(slicer, arrays)`` where ``slicer`` is a tuple of slice objects
+    # used to flip the arrays (or ``None`` if there was no flipping),
+    # and ``arrays`` is the list of flipped arrays.
+    # NOTE: Every input array A must have the same value for the following
+    # expression:  np.sign(A.strides)
+    # NOTE: ``slicer`` is its own inverse, so ``A[slicer][slicer] == A``
+    if isinstance(arrays, GPUArray):
+        raise TypeError("_flip_negative_strides expects a list of GPUArrays")
+    slicer = None
+    ndim = arrays[0].ndim
+    shape = arrays[0].shape
+    for t in zip(range(ndim), *[np.sign(x.strides) for x in arrays]):
+        axis = t[0]
+        stride_sign = t[1]
+        if len(arrays) > 1:
+            if not np.all(t[2:] == stride_sign):
+                raise ValueError("found differing signs in dimension %d: %s" % (axis, t[1:]))
+        if stride_sign == -1:
+            if slicer is None:
+                slicer = [slice(None)] * ndim
+            slicer[axis] = slice(None, None, -1)
+    if slicer is not None:
+        slicer = tuple(slicer)
+        arrays = [x[slicer] for x in arrays]
+    return slicer, arrays
+
+
+def _compact_positive_strides(a):
+    # Flip ``a``'s axes if there are any negative strides, then compute
+    # strides to have same order as a, but packed.  Return flipped ``a``
+    # and packed strides.
+    slicer, alist = _flip_negative_strides((a,))
+    a = alist[0]
     info = sorted(
             (a.strides[axis], a.shape[axis], axis)
             for axis in range(len(a.shape)))
@@ -1191,7 +1270,7 @@ def _compact_strides(a):
     for _, dim, axis in info:
         strides[axis] = stride
         stride *= dim
-    return strides
+    return a, strides, slicer
 
 
 def _memcpy_discontig(dst, src, async=False, stream=None):
@@ -1216,6 +1295,8 @@ def _memcpy_discontig(dst, src, async=False, stream=None):
         dst[...] = src
         return
 
+    src, dst = _flip_negative_strides((src, dst))[1]
+    
     if src.flags.forc and dst.flags.forc:
         shape = [src.size]
         src_strides = dst_strides = [src.dtype.itemsize]


### PR DESCRIPTION
This supercedes #171 after I polluted my original 'noncontig' branch with some commits.  This squashes all the related updates into reasonably partitioned changes.

Issues that may be impacted/fixed by this include:
#15, #66, #121, #145, #151, #154, #162

Here is the original comment from the original commit:

Inspired by:
  https://lists.tiker.net/pipermail/pycuda/2016-December/004986.html
  https://gitlab.tiker.net/inducer/pycuda/merge_requests/1

I tried a new approach to supporting non-contiguous arrays in PyCUDA (could be ported to PyOpenCL somewhat easily I think).  The goals (some elicited by the above discussion and comments in the WIP) were:
- element-wise support for arbitrarily-strided arrays (including negative strides)
- backwards compatibility with current uses of ``get_elwise_module`` and ``get_elwise_range_module``
- limited performance impact on contiguous arrays
- avoid use of '*', '%', and '/' in calculating indices, at least within the element-wise loop

The only way I could think to support all those goals was to delay compilation (and source generation) to call-time, to take advantage of knowledge of input array strides.  Contiguous arrays get the kernels that PyCUDA has always given them, non-contiguous arrays get specialized kernels.  The nice thing about doing this is that the actual shape and strides can be sent as '#define's to aid compiler optimization (could even help with the contiguous kernels).  The tricky thing about doing this is that some functions in the current implementation require the Module/Function before call-time, to get texrefs etc.  So I basically implemented a Proxy class for SourceModule, called ``DeferredSourceModule`` which also defers the generation of the values created by ``get_function()``, ``get_texref()``, etc. until call-time.

To make this all work, indexing (for non-contiguous arrays at least) for an array ``A`` needs to be ``A[A_i]``, rather than ``A[i]``.  If it detects matching contiguous arrays as inputs, then ``X_i`` is '#define'd to be ``i``, so kernels using the old method will still work (as long as the input arrays are contiguous and match in strides).  No regexes needed to transform the user-specified kernel fragments, it's all directed by the user.  Also, if you want to support non-contiguous arrays, you need to send the actual ``GPUArray`` objects, rather than their ``gpudata`` members to the call or prepare_ functions.

All existing tests succeed.  More would probably need to be added if it made sense to integrate this into PyCUDA.

Positive side-effects: ``GPUArray.get()`` and ``GPUArray.copy()`` now work for arbitrarily sliced/strided arrays.

The performance hit for contiguous arrays is around 15% for modest-sized arrays (i.e. the 1000x100 array tested by Keegan in the above discussion) and, looking at profiling output, I think the hit is due to generating the key (in ``ElementwiseSourceModule.create_key()``) for hashing cached kernels.  This could probably be fixed.  Performance for non-contiguous arrays is _infinitely_ better, given that they weren't supported before, but I've seen a 40% slowdown over the contiguous version for the ``b1[::2,:-1]**2`` test Keegan tried, due to the need to calculate indexes at each iteration of the loop.  It tries to do this in a smart way, by pre-calculating the per-thread step for each dimension, and only using division/modulo to calculate the starting indices for each thread before the loop.

Independently of whether these changes are merged in, I will continue to use and develop them to support some local needs, so comments are welcome.  I hope this is useful!


