### PR TITLE
ElementwiseKernel: add get_global and fix bug in get_texref

### DIFF
--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -172,8 +172,12 @@ class ElementwiseKernel:
             operation=operation, arguments=arguments))
 
     def get_texref(self, name, use_range=False):
-        mod, knl, arguments = self.generate_stride_kernel_and_types(use_range=use_range)
+        mod, knl, arguments = self.generate_stride_kernel_and_types(use_range)
         return mod.get_texref(name)
+
+    def get_global(self, name, use_range=False):
+        mod, knl, arguments = self.generate_stride_kernel_and_types(use_range)
+        return mod.get_global(name)
 
     @memoize_method
     def generate_stride_kernel_and_types(self, use_range):


### PR DESCRIPTION
This adds get_global to ElementwiseKernel so you can use constant memory in one.

get_texref was also broken: the use_range parameter was a kwarg instead of normal arg, causing the memoizer to see it as a different call. So you'd get a texref to a different module.