### PR TITLE
Fix documentation related to stop_profiler method.

### DIFF
--- a/doc/source/driver.rst
+++ b/doc/source/driver.rst
@@ -1986,7 +1986,7 @@ CUDA 4.0 and newer.
 
     .. versionadded:: 2011.1
 
-.. function:: stop()
+.. function:: stop_profiler()
 
     .. versionadded:: 2011.1
 


### PR DESCRIPTION
The documentation incorrectly states that the method is called stop whereas the correct name is stop_profiler.