### PR TITLE
fix to make device_allocation.as_buffer() result writable

### DIFF
--- a/src/cpp/cuda.hpp
+++ b/src/cpp/cuda.hpp
@@ -1556,7 +1556,7 @@ namespace pycuda
             py::handle<>(
 #if PY_VERSION_HEX >= 0x03030000
               PyMemoryView_FromMemory((char *) (m_devptr + offset), size,
-                PyBUF_READ | PyBUF_WRITE)
+                PyBUF_WRITE)
 #else /* Py2 */
               PyBuffer_FromReadWriteMemory((void *) (m_devptr + offset), size)
 #endif


### PR DESCRIPTION
Previously the same fix has been applied to pointer_holder_base.as_buffer but not for device_allocation class.