### PR TITLE
Fix two test failures with CUDA 9.2 on Windows

### DIFF
--- a/test/test_cumath.py
+++ b/test/test_cumath.py
@@ -78,9 +78,9 @@ if have_pycuda():
     test_sqrt = make_unary_function_test("sqrt", 1e-5, 1, 2e-7)
 
     test_sin = make_unary_function_test("sin", -10, 10, 1e-7)
-    test_sin_c = make_unary_function_test("sin", -3, 3, 2e-6, complex=True)
+    test_sin_c = make_unary_function_test("sin", -3, 3, 2.1e-6, complex=True)
     test_cos = make_unary_function_test("cos", -10, 10, 1e-7)
-    test_cos_c = make_unary_function_test("cos", -3, 3, 2e-6, complex=True)
+    test_cos_c = make_unary_function_test("cos", -3, 3, 2.1e-6, complex=True)
     test_asin = make_unary_function_test("asin", -0.9, 0.9, 5e-7)
     #test_sin_c = make_unary_function_test("sin", -0.9, 0.9, 2e-6, complex=True)
     test_acos = make_unary_function_test("acos", -0.9, 0.9, 5e-7)


### PR DESCRIPTION
```
============================= test session starts =============================
platform win32 -- Python 3.7.0, pytest-3.7.0, py-1.5.4, pluggy-0.7.1
rootdir: D:\Build\PyCUDA\pycuda-git, inifile:
plugins: xdist-1.22.5, pep8-1.0.6, forked-0.2, faulthandler-1.5.0, cov-2.5.1, palladium-1.2.0, hypothesis-3.66.22, celery-4.2.1
collected 28 items

test_cumath.py ..............F.F...........                              [100%]

================================== FAILURES ===================================
_________________________________ test_sin_c __________________________________

args = (), kwargs = {}
pycuda = <module 'pycuda' from 'X:\\Python37\\lib\\site-packages\\pycuda\\__init__.py'>
ctx = <pycuda._driver.Context object at 0x00000275B7D314A8>
clear_context_caches = <function clear_context_caches at 0x00000275A42C4048>
collect = <built-in function collect>

    def f(*args, **kwargs):
        import pycuda.driver
        # appears to be idempotent, i.e. no harm in calling it more than once
        pycuda.driver.init()

        ctx = make_default_context()
        try:
            assert isinstance(ctx.get_device().name(), str)
            assert isinstance(ctx.get_device().compute_capability(), tuple)
            assert isinstance(ctx.get_device().get_attributes(), dict)
>           inner_f(*args, **kwargs)

X:\Python37\lib\site-packages\pycuda\tools.py:460:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def test():
        gpu_func = getattr(cumath, name)
        cpu_func = getattr(np, numpy_func_names.get(name, name))
        if complex:
            _dtypes = complex_dtypes
        else:
            _dtypes = dtypes

        for s in sizes:
            for dtype in _dtypes:
                np.random.seed(1)
                A = (np.random.random(s)*(b-a) + a).astype(dtype)
                if complex:
                    A += (np.random.random(s)*(b-a) + a)*1j

                args = gpuarray.to_gpu(A)
                gpu_results = gpu_func(args).get()
                cpu_results = cpu_func(A)

                max_err = np.max(np.abs(cpu_results - gpu_results))
>               assert (max_err <= threshold).all(), \
                        (max_err, name, dtype)
E               AssertionError: (2.0370492e-06, 'sin', <class 'numpy.complex64'>)
E               assert False
E                +  where False = <built-in method all of numpy.bool_ object at 0x00007FFA6F172EB0>()
E                +    where <built-in method all of numpy.bool_ object at 0x00007FFA6F172EB0> = 2.0370492e-06 <= 2e-06.all

test_cumath.py:56: AssertionError
_________________________________ test_cos_c __________________________________

args = (), kwargs = {}
pycuda = <module 'pycuda' from 'X:\\Python37\\lib\\site-packages\\pycuda\\__init__.py'>
ctx = <pycuda._driver.Context object at 0x00000275B82100E0>
clear_context_caches = <function clear_context_caches at 0x00000275A42C4048>
collect = <built-in function collect>

    def f(*args, **kwargs):
        import pycuda.driver
        # appears to be idempotent, i.e. no harm in calling it more than once
        pycuda.driver.init()

        ctx = make_default_context()
        try:
            assert isinstance(ctx.get_device().name(), str)
            assert isinstance(ctx.get_device().compute_capability(), tuple)
            assert isinstance(ctx.get_device().get_attributes(), dict)
>           inner_f(*args, **kwargs)

X:\Python37\lib\site-packages\pycuda\tools.py:460:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def test():
        gpu_func = getattr(cumath, name)
        cpu_func = getattr(np, numpy_func_names.get(name, name))
        if complex:
            _dtypes = complex_dtypes
        else:
            _dtypes = dtypes

        for s in sizes:
            for dtype in _dtypes:
                np.random.seed(1)
                A = (np.random.random(s)*(b-a) + a).astype(dtype)
                if complex:
                    A += (np.random.random(s)*(b-a) + a)*1j

                args = gpuarray.to_gpu(A)
                gpu_results = gpu_func(args).get()
                cpu_results = cpu_func(A)

                max_err = np.max(np.abs(cpu_results - gpu_results))
>               assert (max_err <= threshold).all(), \
                        (max_err, name, dtype)
E               AssertionError: (2.0370492e-06, 'cos', <class 'numpy.complex64'>)
E               assert False
E                +  where False = <built-in method all of numpy.bool_ object at 0x00007FFA6F172EB0>()
E                +    where <built-in method all of numpy.bool_ object at 0x00007FFA6F172EB0> = 2.0370492e-06 <= 2e-06.all

test_cumath.py:56: AssertionError
==================== 2 failed, 26 passed in 74.59 seconds =====================
```