### PR TITLE
replaced deprecated numpy.random.random_integers with randint

### DIFF
--- a/pycuda/curandom.py
+++ b/pycuda/curandom.py
@@ -608,8 +608,8 @@ class _PseudoRandomNumberGeneratorBase(_RandomNumberGeneratorBase):
         if seed_getter is None:
             seed = array.to_gpu(
                     np.asarray(
-                        np.random.random_integers(
-                            0, (1 << 31) - 2, generator_count),
+                        np.random.randint(
+                            0, (1 << 31) - 1, generator_count),
                         dtype=np.int32))
         else:
             seed = seed_getter(generator_count)


### PR DESCRIPTION
Fixed DeprecationWarning:

> curandom.py:612: DeprecationWarning: This function is deprecated. Please call randint(0, 2147483646 + 1) instead
>   0, (1 << 31) - 2, generator_count),

(numpy.random.random_integers: Deprecated since version 1.11.0.)