### PR TITLE
Pytest is a test-requirement not a runtime requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -208,10 +208,13 @@ def main():
 
             install_requires=[
                 "pytools>=2011.2",
-                "pytest>=2",
                 "decorator>=3.2.0",
                 "appdirs>=1.4.0",
                 "mako",
+                ],
+
+            test_requires=[
+                "pytest>=2",
                 ],
 
             ext_package="pycuda",


### PR DESCRIPTION
Installing pycuda shouldn't bring in a test runtime, only
when you are planning to run the test suite of pycuda should
this be brought in.