### PR TITLE
add "out" parameter to GPUArray.conj(); add equivalent GPUArray.conjugate() method

### DIFF
--- a/doc/source/array.rst
+++ b/doc/source/array.rst
@@ -189,11 +189,25 @@ The :class:`GPUArray` Array Class
 
         .. versionadded: 0.94
 
-    .. method :: conj()
+    .. method :: conj(out=None)
 
-        Return the complex conjugate of *self*, or *self* if it is real.
+        Return the complex conjugate of *self*, or *self* if it is real. If *out*
+        is not given, a newly allocated :class:`GPUArray` will returned. Use
+        *out=self* to get conjugate in-place.
 
         .. versionadded: 0.94
+
+        .. versionchanged:: 2020.1.1
+
+            add *out* parameter
+
+
+    .. method :: conjugate(out=None)
+
+        alias of :meth:`conj`
+
+        .. versionadded:: 2020.1.1
+
 
     .. method:: bind_to_texref(texref, allow_offset=False)
 

--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -606,11 +606,12 @@ def get_imag_kernel(dtype, real_dtype):
 
 
 @context_dependent_memoize
-def get_conj_kernel(dtype):
+def get_conj_kernel(dtype, conj_dtype):
     return get_elwise_kernel(
-        "%(tp)s *y, %(tp)s *z"
+        "%(tp)s *y, %(conj_tp)s *z"
         % {
             "tp": dtype_to_ctype(dtype),
+            "conj_tp": dtype_to_ctype(conj_dtype)
         },
         "z[i] = pycuda::conj(y[i])",
         "conj",

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -1141,7 +1141,7 @@ class GPUArray:
         else:
             return zeros_like(self)
 
-    def conj(self):
+    def conj(self, out=None):
         dtype = self.dtype
         if issubclass(self.dtype.type, np.complexfloating):
             if not self.flags.forc:
@@ -1154,9 +1154,12 @@ class GPUArray:
                 order = "F"
             else:
                 order = "C"
-            result = self._new_like_me(order=order)
+            if out is None:
+                result = self._new_like_me(order=order)
+            else:
+                result = out
 
-            func = elementwise.get_conj_kernel(dtype)
+            func = elementwise.get_conj_kernel(dtype, result.dtype)
             func.prepared_async_call(
                 self._grid,
                 self._block,
@@ -1169,6 +1172,8 @@ class GPUArray:
             return result
         else:
             return self
+
+    conjugate = conj
 
     # }}}
 

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -732,6 +732,10 @@ class TestGPUArray:
             assert la.norm(z.get().real - z.real.get()) == 0
             assert la.norm(z.get().imag - z.imag.get()) == 0
             assert la.norm(z.get().conj() - z.conj().get()) == 0
+            # verify conj with out parameter
+            z_out = z.astype(np.complex64)
+            assert z_out is z.conj(out=z_out)
+            assert la.norm(z.get().conj() - z_out.get()) < 1e-7
 
             # verify contiguity is preserved
             for order in ["C", "F"]:


### PR DESCRIPTION
Similar to np.conj/conjugate function

Advantages:
- easy to do in-place conjugate, and
- write conjugate result to another GPUArray
- self.conjugate() is compatible with both python built-in number types (for example: `(1).conjugate()`, `(1+2j).conjugate()` ...) and numpy ndarray
