### PR TITLE
Add a pyproject.toml to control build-time numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+
+# For each Python version, build against the oldest numpy C_API_VERSION for
+# which binary numpy wheels exist, and then the newest version of numpy
+# implementing that C_API_VERSION.
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy; python_version >= '3.10'",
+    "numpy==1.19.5; python_version >= '3.8' and python_version < '3.10'",
+    "numpy==1.15.4; python_version >= '3.7' and python_version < '3.8'",
+    "numpy==1.12.1; python_version < '3.7'",
+]


### PR DESCRIPTION
Build against the oldest C_API_VERSION available for the current Python
version, to maximise compatibility of the resulting installation.

Closes #271.