### PR TITLE
doc/source/index.rst: remove duplicate reikna entry

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -88,7 +88,6 @@ feel should be listed here, please submit a PR!
 * `pyvkfft <https://github.com/vincefn/pyvkfft>`__
 * `scikit-cuda <https://scikit-cuda.readthedocs.io/en/latest/>`__
 * `reikna <https://pypi.org/project/reikna/>`__
-* `reikna <https://pypi.org/project/reikna/>`__
 * `compyle <https://pypi.org/project/compyle/>`__
 * `pynufft <https://pypi.org/project/pynufft/>`__
 


### PR DESCRIPTION
This PR is pretty simple -- it removes duplicate 'reikna' entry from the 'Other Software' list
