### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -926,7 +926,7 @@ def has_flag(compiler, flagname):
 def cpp_flag(compiler):
     """Return the -std=c++[11/14] compiler flag.
 
-    The c++14 is prefered over c++11 (when it is available).
+    The c++14 is preferred over c++11 (when it is available).
     """
     if has_flag(compiler, '-std=gnu++14'):
         return '-std=gnu++14'

--- a/examples/from-wiki/mandelbrot_interactive.py
+++ b/examples/from-wiki/mandelbrot_interactive.py
@@ -11,7 +11,7 @@
 
 # Point and click with the right buttom to magnify by a factor of 10
 
-# Click with the left button on the rigth side of the 
+# Click with the left button on the right side of the 
 # image to randomly change the colormap
 
 # Click with right button on the right side of the image to set the default colormap

--- a/pycuda/cuda/pycuda-helpers.hpp
+++ b/pycuda/cuda/pycuda-helpers.hpp
@@ -102,7 +102,7 @@ extern "C++" {
     return pycuda::complex<double>(__hiloint2double(v.y, v.x), __hiloint2double(v.w, v.z));
   }
 
-  // FP_Surfaces with complex supprt
+  // FP_Surfaces with complex support
 
   __device__ void fp_surf2DLayeredwrite(double var,surface<void, cudaSurfaceType2DLayered> surf, int i, int j, int layer, enum cudaSurfaceBoundaryMode mode)
   {

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -154,7 +154,7 @@ class TestGPUArray:
 
     @mark_cuda_test
     def test_substract_array(self):
-        """Test the substraction of two arrays."""
+        """Test the subtraction of two arrays."""
         # test data
         a = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).astype(np.float32)
         b = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]).astype(np.float32)
@@ -170,7 +170,7 @@ class TestGPUArray:
 
     @mark_cuda_test
     def test_substract_scalar(self):
-        """Test the substraction of an array and a scalar."""
+        """Test the subtraction of an array and a scalar."""
 
         # test data
         a = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).astype(np.float32)


### PR DESCRIPTION
There are small typos in:
- aksetup_helper.py
- examples/from-wiki/mandelbrot_interactive.py
- pycuda/cuda/pycuda-helpers.hpp
- test/test_gpuarray.py

Fixes:
- Should read `subtraction` rather than `substraction`.
- Should read `support` rather than `supprt`.
- Should read `right` rather than `rigth`.
- Should read `preferred` rather than `prefered`.

Closes #294