### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,9 @@ def main():
         author_email="inform@tiker.net",
         license="MIT",
         url="http://mathema.tician.de/software/pycuda",
+        project_urls={
+            "Source": "https://github.com/inducer/pycuda",
+        },
         classifiers=[
             "Environment :: Console",
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)