### PR TITLE
Bump Python compat target to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
             uses: actions/setup-python@v1
             with:
                 # matches compat target in setup.py
-                python-version: '3.6'
+                python-version: '3.8'
         -   name: "Main Script"
             run: |
                 curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-flake8.sh

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ def main():
         setup_requires=[
             "numpy>=1.6",
         ],
-        python_requires="~=3.6",
+        python_requires="~=3.8",
         install_requires=[
             "pytools>=2011.2",
             "appdirs>=1.4.0",


### PR DESCRIPTION
https://gitlab.tiker.net/inducer/pycuda/-/merge_requests/77 inadvertently bumped the Python compatibility target to no longer be 3.8, as evidenced by this failure:

https://github.com/inducer/pycuda/runs/7641044636?check_suite_focus=true#step:4:89

For posterity, that is:
```
pycuda/gpuarray.py:2151:25: E999 SyntaxError: invalid syntax
```

cc @kaushikcfd @mitkotak 