### PR TITLE
Fix operations issues on large arrays

### DIFF
--- a/pycuda/elementwise.py
+++ b/pycuda/elementwise.py
@@ -54,10 +54,10 @@ def get_elwise_module(
         __global__ void %(name)s(%(arguments)s)
         {
 
-          unsigned tid = threadIdx.x;
-          unsigned total_threads = gridDim.x*blockDim.x;
-          unsigned cta_start = blockDim.x*blockIdx.x;
-          unsigned i;
+          size_t tid = threadIdx.x;
+          size_t total_threads = gridDim.x*blockDim.x;
+          size_t cta_start = blockDim.x*blockIdx.x;
+          size_t i;
 
           %(loop_prep)s;
 
@@ -104,10 +104,10 @@ def get_elwise_range_module(
         extern "C"
         __global__ void %(name)s(%(arguments)s)
         {
-          unsigned tid = threadIdx.x;
-          unsigned total_threads = gridDim.x*blockDim.x;
-          unsigned cta_start = blockDim.x*blockIdx.x;
-          long i;
+          size_t tid = threadIdx.x;
+          size_t total_threads = gridDim.x*blockDim.x;
+          size_t cta_start = blockDim.x*blockIdx.x;
+          size_t i;
 
           %(loop_prep)s;
 

--- a/pycuda/reduction.py
+++ b/pycuda/reduction.py
@@ -205,7 +205,7 @@ def get_reduction_kernel_and_types(
 
     func = mod.get_function(name)
     arg_types = [get_arg_type(arg) for arg in arguments.split(",")]
-    func.prepare("P%sII" % "".join(arg_types))
+    func.prepare("P%sIn" % "".join(arg_types))
 
     return func, arg_types
 

--- a/pycuda/reduction.py
+++ b/pycuda/reduction.py
@@ -91,7 +91,7 @@ def get_reduction_module(
         extern "C"
         __global__
         void %(name)s(out_type *out, %(arguments)s,
-          unsigned int seq_count, unsigned int n)
+          size_t seq_count, size_t n)
         {
           // Needs to be variable-size to prevent the braindead CUDA compiler from
           // running constructors on this array. Grrrr.
@@ -99,10 +99,10 @@ def get_reduction_module(
 
           unsigned int tid = threadIdx.x;
 
-          unsigned int i = blockIdx.x*BLOCK_SIZE*seq_count + tid;
+          size_t i = blockIdx.x*BLOCK_SIZE*seq_count + tid;
 
           out_type acc = %(neutral)s;
-          for (unsigned s = 0; s < seq_count; ++s)
+          for (size_t s = 0; s < seq_count; ++s)
           {
             if (i >= n)
               break;

--- a/pycuda/reduction.py
+++ b/pycuda/reduction.py
@@ -91,7 +91,7 @@ def get_reduction_module(
         extern "C"
         __global__
         void %(name)s(out_type *out, %(arguments)s,
-          size_t seq_count, size_t n)
+          unsigned int seq_count, size_t n)
         {
           // Needs to be variable-size to prevent the braindead CUDA compiler from
           // running constructors on this array. Grrrr.
@@ -102,7 +102,7 @@ def get_reduction_module(
           size_t i = blockIdx.x*BLOCK_SIZE*seq_count + tid;
 
           out_type acc = %(neutral)s;
-          for (size_t s = 0; s < seq_count; ++s)
+          for (unsigned s = 0; s < seq_count; ++s)
           {
             if (i >= n)
               break;

--- a/pycuda/scan.py
+++ b/pycuda/scan.py
@@ -104,7 +104,7 @@ void ${name_prefix}_scan_intervals(
 
     const unsigned int unit_size  = K * WG_SIZE;
 
-    unsigned int unit_base = interval_begin;
+    size_t unit_base = interval_begin;
 
     %for is_tail in [False, True]:
 


### PR DESCRIPTION
## About


This MR fixes a "pycuda hanging forever" issue when array sizes exceed `2**34` bytes. 
It's done by replacing some occurrences of `unsigned (int)` with `size_t` in template kernels (element-wise, reduction, scan).

Close #375 

The tests had to be done on arrays of `double` to avoid numerical issues.

## ElementWise

```python
import numpy as np
import pycuda.autoinit
import pycuda.gpuarray as garray
from pycuda.elementwise import ElementwiseKernel
eltwise = ElementwiseKernel("double* d_arr", "d_arr[i] = i", "linspace")
d_arr = garray.empty((512, 2048, 2048), np.float64)
eltwise(d_arr)
result = d_arr.get()[()]
reference = np.arange(d_arr.size, dtype=np.float64).reshape(d_arr.shape)
assert np.allclose(result, reference)
```


## Reduction

```python
import numpy as np
import pycuda.autoinit
import pycuda.gpuarray as garray
from pycuda.reduction import ReductionKernel

reduction = ReductionKernel(np.float64, neutral="0", reduce_expr="a+b", map_expr="x[i]", arguments="double* x")
d_arr = garray.zeros((512, 2048, 2048), np.float64)
d_arr.fill(1) # elementwise
result = reduction(d_arr.ravel()).get()[()]
assert result == d_arr.size
```

## Scan

```python
import numpy as np
import pycuda.autoinit
import pycuda.gpuarray as garray
from pycuda.scan import InclusiveScanKernel

cumsum = InclusiveScanKernel(np.float64, "a+b")
d_arr = garray.zeros((512, 2048, 2048), np.float64)
d_arr.fill(1)
result = cumsum(d_arr.ravel()).get()[()]
assert result[-1] == d_arr.size
```
