### PR TITLE
Prevent warning on nvcc_path add

### DIFF
--- a/pycuda/driver.py
+++ b/pycuda/driver.py
@@ -38,6 +38,7 @@ def _add_cuda_libdir_to_dll_path():
     nvcc_path = _search_on_path(["nvcc.exe"])
     if nvcc_path is not None:
         os.add_dll_directory(dirname(nvcc_path))
+        return
 
     from warnings import warn
 


### PR DESCRIPTION
If pycuda has detected a CUDA runtime via nvcc.exe discovery, return to prevent a misleading warning, consistent with CUDA_PATH usage above.