### PR TITLE
Pin build-time numpy versions for Python 3.10 and 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy; python_version >= '3.10'",
+    "numpy; python_version >= '3.12'",
+    "numpy==1.23.4; python_version >= '3.11' and python_version < '3.12'",
+    "numpy==1.21.6; python_version >= '3.10' and python_version < '3.11'",
     "numpy==1.19.5; python_version >= '3.8' and python_version < '3.10'",
     "numpy==1.15.4; python_version >= '3.7' and python_version < '3.8'",
     "numpy==1.12.1; python_version < '3.7'",


### PR DESCRIPTION
This avoid errors when trying to use with a numpy version that's older than the one that was newest when pycuda was built. See https://github.com/inducer/pycuda/issues/271 for background on why this is useful.