### PR TITLE
use oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,5 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy; python_version >= '3.12'",
-    "numpy==1.23.4; python_version >= '3.11' and python_version < '3.12'",
-    "numpy==1.21.6; python_version >= '3.10' and python_version < '3.11'",
-    "numpy==1.19.5; python_version >= '3.8' and python_version < '3.10'",
-    "numpy==1.15.4; python_version >= '3.7' and python_version < '3.8'",
-    "numpy==1.12.1; python_version < '3.7'",
+    "oldest-supported-numpy",
 ]


### PR DESCRIPTION
CI on gitlab: https://gitlab.tiker.net/inducer/pycuda/-/merge_requests/new?merge_request%5Bsource_branch%5D=oldest-numpy