### PR TITLE
Remove setup_requires to avoid dependency resolution issues with Poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,9 +217,6 @@ def main():
         ],
         # build info
         packages=["pycuda", "pycuda.gl", "pycuda.sparse", "pycuda.compyte"],
-        setup_requires=[
-            "numpy>=1.6",
-        ],
         python_requires="~=3.8",
         install_requires=[
             "pytools>=2011.2",


### PR DESCRIPTION
Since the build-time Numpy version is already controlled by `build-system.requires` in `pyproject.toml`, it is not necessary to specify the Numpy version in `setup.py`. The latter would cause dependency resolution issues when PyCuda is installed using Poetry, see [this issue](https://github.com/python-poetry/poetry/issues/8830) 