### PR TITLE
fix defaults for mingw builds

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -643,6 +643,9 @@ def set_up_shipped_boost_if_requested(project_name, conf, source_path=None,
                 "boost": "%sboost" % project_name,
                 }
 
+        if os.environ.get("MINGW_CHOST"):
+            defines["BOOST_USE_WINDOWS_H"] = 1
+
         if boost_chrono is False:
             defines["BOOST_THREAD_DONT_USE_CHRONO"] = 1
         elif boost_chrono == "header_only":

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,11 @@ def get_config_schema():
         # https://github.com/inducer/pycuda/issues/113
         lib64 = "lib/x64"
 
-        cxxflags_default.extend(["/EHsc"])
-        ldflags_default.extend(["/FORCE"])
+        import os
+        if not os.environ.get("MINGW_CHOST"):
+            cxxflags_default.extend(["/EHsc"])
+            ldflags_default.extend(["/FORCE"])
+
     elif "darwin" in sys.platform:
         import glob
 


### PR DESCRIPTION
* we have to set BOOST_USE_WINDOWS_H=1 because of this bug: http://stackoverflow.com/questions/18134148
* remove '/EHsc' and '/FORCE' when compiling with mingw instead of msvc