### PR TITLE
Use stream in mul_add if given and allocator in subset_sum

### DIFF
--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -2087,8 +2087,7 @@ def subset_sum(subset, a, dtype=None, stream=None, allocator=None):
     from pycuda.reduction import get_subset_sum_kernel
 
     krnl = get_subset_sum_kernel(dtype, subset.dtype, a.dtype)
-    return krnl(subset, a, stream=stream,
-                allocator=drv.mem_alloc if allocator is None else allocator)
+    return krnl(subset, a, stream=stream, allocator=allocator)
 
 
 def dot(a, b, dtype=None, stream=None, allocator=None):

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -574,10 +574,10 @@ class GPUArray:
         )
 
     # operators ---------------------------------------------------------------
-    def mul_add(self, selffac, other, otherfac, add_timer=None, stream=None):
+    def mul_add(self, selffac, other, otherfac, add_timer=None, stream=None, out=None):
         """Return `selffac * self + otherfac*other`."""
-        result = self._new_like_me(_get_common_dtype(self, other))
-        return self._axpbyz(selffac, other, otherfac, result, add_timer)
+        result = self._new_like_me(_get_common_dtype(self, other)) if out is None else out
+        return self._axpbyz(selffac, other, otherfac, result, add_timer, stream=stream)
 
     def __add__(self, other):
         """Add an array with an array or an array with a scalar."""
@@ -2087,7 +2087,8 @@ def subset_sum(subset, a, dtype=None, stream=None, allocator=None):
     from pycuda.reduction import get_subset_sum_kernel
 
     krnl = get_subset_sum_kernel(dtype, subset.dtype, a.dtype)
-    return krnl(subset, a, stream=stream)
+    return krnl(subset, a, stream=stream,
+                allocator=drv.mem_alloc if allocator is None else allocator)
 
 
 def dot(a, b, dtype=None, stream=None, allocator=None):

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -576,7 +576,7 @@ class GPUArray:
     # operators ---------------------------------------------------------------
     def mul_add(self, selffac, other, otherfac, add_timer=None, stream=None, out=None):
         """Return `selffac * self + otherfac*other`."""
-        result = self._new_like_me(_get_common_dtype(self, other)) if out is None else out
+        result = out if out is not None else self._new_like_me(_get_common_dtype(self, other))
         return self._axpbyz(selffac, other, otherfac, result, add_timer, stream=stream)
 
     def __add__(self, other):

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -884,7 +884,6 @@ class TestGPUArray:
 
     def test_subset_sum(self):
         """Test subset sum with annd without allocator"""
-        from pycuda.curandom import rand as curand
 
         l_a = 2000
         gran = 5
@@ -898,7 +897,7 @@ class TestGPUArray:
         import pycuda.tools
         for pool in [None, pycuda.tools.DeviceMemoryPool()]:
             for dtype in dtypes:
-                a = np.random.uniform(0,10, l_a).astype(dtype)
+                a = np.random.uniform(0, 10, l_a).astype(dtype)
                 a_gpu = gpuarray.to_gpu(a)
 
                 meaningful_indices_gpu = gpuarray.zeros(l_m, dtype=np.int32)


### PR DESCRIPTION
Hi Andreas,

Somehow gpuarrays' `mul_add` did not use the supplied `stream` parameter. Similarly, the `allocator` parameter of `subset_sum` was not used either. 

This PR should fix that, and also adds an optional `out` parameter to `mul_add`.
