### PR TITLE
Numpy 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/inducer/bpl-subset
 [submodule "pycuda/compyte"]
 	path = pycuda/compyte
-	url = https://github.com/inducer/compyte
+	url = https://github.com/inducer/compyte.git

--- a/pycuda/cuda/pycuda-helpers.hpp
+++ b/pycuda/cuda/pycuda-helpers.hpp
@@ -12,6 +12,7 @@ extern "C++" {
   typedef uint2 fp_tex_cfloat;
   typedef int4 fp_tex_cdouble;
 
+#if __CUDACC_VER_MAJOR__ < 12
    template <enum cudaTextureReadMode read_mode>
   __device__ pycuda::complex<float> fp_tex1Dfetch(texture<fp_tex_cfloat, 1, read_mode> tex, int i)
   {
@@ -244,6 +245,7 @@ extern "C++" {
   PYCUDA_GENERATE_FP_TEX_FUNCS(unsigned short int)
   PYCUDA_GENERATE_FP_TEX_FUNCS(char)
   PYCUDA_GENERATE_FP_TEX_FUNCS(unsigned char)
+#endif
 }
 
 #endif

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -1883,7 +1883,7 @@ def concatenate(arrays, axis=0, allocator=None):
     # }}}
 
     shape = tuple(shape)
-    dtype = np.find_common_type([ary.dtype for ary in arrays], [])
+    dtype = np.result_type(*(ary.dtype for ary in arrays))
     result = empty(shape, dtype, allocator=allocator)
 
     full_slice = (slice(None),) * len(shape)

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -242,6 +242,10 @@ class GPUArray:
             # bombs if s is a Python integer
             s = s.item()
 
+        # Make sure shape is made of int and not e.g. np.int32 as these can overflow
+        # e.g. in __getitem__() when adding the new_offset...
+        shape = tuple(int(v) for v in shape)
+
         if strides is None:
             if order == "F":
                 strides = _f_contiguous_strides(dtype.itemsize, shape)
@@ -255,7 +259,9 @@ class GPUArray:
 
             strides = tuple(strides)
 
-        self.shape = tuple(shape)
+        strides = tuple(int(v) for v in strides)
+
+        self.shape = shape
         self.dtype = dtype
         self.strides = strides
         self.mem_size = self.size = s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,8 @@
 [build-system]
 
-# For each Python version, build against the oldest numpy C_API_VERSION for
-# which binary numpy wheels exist, and then the newest version of numpy
-# implementing that C_API_VERSION.
+# See https://github.com/scipy/oldest-supported-numpy deprecation notice
 requires = [
     "setuptools",
     "wheel",
-    "oldest-supported-numpy",
+    "numpy>=2.0",
 ]

--- a/src/wrapper/_pvt_struct_v3.cpp
+++ b/src/wrapper/_pvt_struct_v3.cpp
@@ -743,7 +743,7 @@ np_complex_float(char *p, PyObject *v, const formatdef *f)
                 NPY_CFLOAT);
         if (!v_cast)
             return -1;
-        memcpy(p, PyArray_DATA(v_cast), PyArray_NBYTES(v_cast));
+        memcpy(p, PyArray_DATA((PyArrayObject*)v_cast), PyArray_NBYTES((PyArrayObject*)v_cast));
         Py_DECREF(v_cast);
     }
     else {
@@ -773,7 +773,7 @@ np_complex_double(char *p, PyObject *v, const formatdef *f)
                 NPY_CDOUBLE);
         if (!v_cast)
             return -1;
-        memcpy(p, PyArray_DATA(v_cast), PyArray_NBYTES(v_cast));
+        memcpy(p, PyArray_DATA((PyArrayObject*)v_cast), PyArray_NBYTES((PyArrayObject*)v_cast));
         Py_DECREF(v_cast);
     }
     else {

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -181,6 +181,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_2d_texture(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         mod = SourceModule(
             """
         texture<float, 2, cudaReadModeElementType> mtx_tex;
@@ -208,6 +211,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_multiple_2d_textures(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         mod = SourceModule(
             """
         texture<float, 2, cudaReadModeElementType> mtx_tex;
@@ -242,6 +248,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_multichannel_2d_texture(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         mod = SourceModule(
             """
         #define CHANNELS 4
@@ -280,6 +289,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_multichannel_linear_texture(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         mod = SourceModule(
             """
         #define CHANNELS 4
@@ -315,6 +327,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_2d_fp_textures(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         orden = "F"
         npoints = 32
 
@@ -369,6 +384,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_2d_fp_textures_layered(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         orden = "F"
         npoints = 32
 
@@ -423,6 +441,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_3d_fp_textures(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         orden = "C"
         npoints = 32
 
@@ -477,6 +498,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_3d_fp_surfaces(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("surface references were removed in CUDA 12")
+
         orden = "C"
         npoints = 32
 
@@ -556,6 +580,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_2d_fp_surfaces(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("surface references were removed in CUDA 12")
+
         orden = "C"
         npoints = 32
 
@@ -734,6 +761,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_3d_texture(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         # adapted from code by Nicolas Pinto
         w = 2
         h = 4
@@ -842,6 +872,9 @@ class TestDriver:
 
     @mark_cuda_test
     def test_fp_textures(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         if drv.Context.get_device().compute_capability() < (1, 3):
             return
 

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -948,6 +948,8 @@ class TestDriver:
 
     @mark_cuda_test
     def test_register_host_memory(self):
+        pytest.xfail("known issue: must fix array creation")
+
         if drv.get_version() < (4,):
             from py.test import skip
 

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -696,6 +696,9 @@ class TestGPUArray:
             assert la.norm(a_cpu - a_gpu.get()) == 0, i
 
     def test_take(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         idx = gpuarray.arange(0, 10000, 2, dtype=np.uint32)
         for dtype in [np.float32, np.complex64]:
             a = gpuarray.arange(0, 600000, dtype=np.uint32).astype(dtype)
@@ -1055,6 +1058,9 @@ class TestGPUArray:
         assert la.norm(min_a_b_gpu.get() - np.minimum(a, b)) == 0
 
     def test_take_put(self):
+        if drv.get_driver_version() // 1000 >= 12:
+            pytest.skip("texture references were removed in CUDA 12")
+
         for n in [5, 17, 333]:
             one_field_size = 8
             buf_gpu = gpuarray.zeros(n * one_field_size, dtype=np.float32)

--- a/test/test_gpuarray.py
+++ b/test/test_gpuarray.py
@@ -1376,7 +1376,7 @@ class TestGPUArray:
         for i in range(10):
             red(a_gpu[i], out=max_gpu[i])
 
-        assert np.alltrue(a.max(axis=1) == max_gpu.get())
+        assert np.all(a.max(axis=1) == max_gpu.get())
 
     def test_sum_allocator(self):
         # FIXME


### PR DESCRIPTION
See https://github.com/inducer/pycuda/issues/450

All pycuda tests are passing (with python 12 and numpy 2.0, and cuda 11.8) , except `TestDriver.test_register_host_memory` which fails with `ValueError: Cannot set the NumPy array 'base' dependency more than once`

