### PR TITLE
Use bytes as output when nvcc version could not be determined

### DIFF
--- a/pycuda/compiler.py
+++ b/pycuda/compiler.py
@@ -19,7 +19,7 @@ def get_nvcc_version(nvcc):
         from warnings import warn
 
         warn("NVCC version could not be determined.")
-        stdout = "nvcc unknown version"
+        stdout = b"nvcc unknown version"
 
     return stdout.decode("utf-8", "replace")
 


### PR DESCRIPTION
When subprocess runs successfully, the stdout is bytes and is decoded later. However, it is set to a `str` literal when the subprocess fails. Change it to bytes literal to get decoded without problem.