### PR TITLE
GPUArray.astype uses stream consistently

### DIFF
--- a/doc/array.rst
+++ b/doc/array.rst
@@ -148,7 +148,7 @@ The :class:`GPUArray` Array Class
         size (not necessarily shape) and dtype. If it is not given,
         a *page-locked* array is newly allocated.
 
-    .. method :: copy()
+    .. method :: copy(stream=None)
 
         .. versionadded :: 2013.1
 
@@ -187,7 +187,7 @@ The :class:`GPUArray` Array Class
 
     .. method :: astype(dtype, stream=None)
 
-        Return *self*, cast to *dtype*.
+        Return copy of the array, cast to a specified type.
 
     .. method :: any(stream=None, allocator=None)
 

--- a/pycuda/gpuarray.py
+++ b/pycuda/gpuarray.py
@@ -396,9 +396,10 @@ class GPUArray:
     def get_async(self, stream=None, ary=None):
         return self.get(ary=ary, async_=True, stream=stream)
 
-    def copy(self):
+    def copy(self, stream=None):
         new = GPUArray(self.shape, self.dtype, self.allocator, strides=self.strides)
-        _memcpy_discontig(new, self)
+        _memcpy_discontig(new, self,
+            **{"async_": True, "stream": stream} if stream is not None else {})
         return new
 
     def __str__(self):
@@ -926,11 +927,11 @@ class GPUArray:
     def astype(self, dtype, stream=None):
         if not self.flags.forc:
             raise RuntimeError(
-                "only contiguous arrays may " "be used as arguments to this operation"
+                "only contiguous arrays may be used as arguments to this operation"
             )
 
         if dtype == self.dtype:
-            return self.copy()
+            return self.copy(stream=stream)
 
         result = self._new_like_me(dtype=dtype)
 


### PR DESCRIPTION
- Add optional `stream` parameter to `GPUArray.copy(self,stream=None)`
- `GPUArray.astype(..., stream)` now respect the `stream` parameter consistently no matter the `dtype` is the same or not
- Update doc